### PR TITLE
feat: Phase 3 — VM Manager CLI (minions crate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/minions-proto",
     "crates/minions-agent",
     "crates/minions-host",
+    "crates/minions",
 ]
 
 [workspace.dependencies]

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "minions"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "minions"
+path = "src/main.rs"
+
+[dependencies]
+minions-proto = { path = "../minions-proto" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
+nix = { version = "0.30", features = ["signal"] }
+libc = "0.2"
+chrono = "0.4"
+tabled = "0.17"

--- a/crates/minions/src/agent.rs
+++ b/crates/minions/src/agent.rs
@@ -1,0 +1,94 @@
+//! VSOCK client: connect, handshake, send requests.
+
+use anyhow::{Context, Result};
+use minions_proto::{read_frame, write_frame, Request, Response};
+use std::path::Path;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::time::sleep;
+
+/// Connect to the VSOCK proxy socket and perform the CONNECT handshake.
+pub async fn connect(vsock_socket: &Path) -> Result<UnixStream> {
+    let mut stream = UnixStream::connect(vsock_socket)
+        .await
+        .with_context(|| format!("connect to {:?}", vsock_socket))?;
+
+    stream
+        .write_all(b"CONNECT 1024\n")
+        .await
+        .context("send CONNECT handshake")?;
+
+    // Consume stream into BufReader so into_inner() returns ownership.
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .await
+        .context("read OK from agent")?;
+
+    if !line.starts_with("OK ") {
+        anyhow::bail!("VSOCK handshake failed: {}", line.trim());
+    }
+
+    Ok(reader.into_inner())
+}
+
+/// Send a single request and read the response.
+pub async fn send_request(vsock_socket: &Path, request: Request) -> Result<Response> {
+    let mut stream = connect(vsock_socket).await?;
+    write_frame(&mut stream, &request)
+        .await
+        .context("write request frame")?;
+    let response: Response = read_frame(&mut stream)
+        .await
+        .context("read response frame")?;
+    Ok(response)
+}
+
+/// Wait until the agent responds to a health check, up to `timeout`.
+pub async fn wait_ready(vsock_socket: &Path, timeout: Duration) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(100);
+
+    loop {
+        match send_request(vsock_socket, Request::HealthCheck).await {
+            Ok(_) => return Ok(()),
+            Err(_) => {}
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "agent at {:?} did not become ready within {:?}",
+                vsock_socket,
+                timeout
+            );
+        }
+
+        sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(2));
+    }
+}
+
+/// Configure guest networking via the agent.
+pub async fn configure_network(
+    vsock_socket: &Path,
+    ip: &str,
+    gateway: &str,
+    dns: Vec<String>,
+) -> Result<()> {
+    let response = send_request(
+        vsock_socket,
+        Request::ConfigureNetwork {
+            ip: ip.to_string(),
+            gateway: gateway.to_string(),
+            dns,
+        },
+    )
+    .await?;
+
+    match response {
+        Response::Ok { .. } => Ok(()),
+        Response::Error { message } => anyhow::bail!("agent error: {message}"),
+    }
+}

--- a/crates/minions/src/db.rs
+++ b/crates/minions/src/db.rs
@@ -1,0 +1,185 @@
+//! SQLite state management for VM lifecycle.
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use std::path::Path;
+
+pub const DB_PATH: &str = "/var/lib/minions/state.db";
+
+/// Represents a VM record in the database.
+#[derive(Debug, Clone)]
+pub struct Vm {
+    pub name: String,
+    pub status: String,
+    pub ip: String,
+    pub vsock_cid: u32,
+    pub ch_pid: Option<i64>,
+    pub ch_api_socket: String,
+    pub ch_vsock_socket: String,
+    pub tap_device: String,
+    pub mac_address: String,
+    pub vcpus: u32,
+    pub memory_mb: u32,
+    pub rootfs_path: String,
+    pub created_at: String,
+    pub stopped_at: Option<String>,
+}
+
+/// Open (or create) the state database.
+pub fn open(path: &str) -> Result<Connection> {
+    // Ensure parent directory exists.
+    if let Some(parent) = Path::new(path).parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create db dir {:?}", parent))?;
+    }
+    let conn = Connection::open(path).context("open sqlite db")?;
+    conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    migrate(&conn)?;
+    Ok(conn)
+}
+
+fn migrate(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS vms (
+            name            TEXT PRIMARY KEY,
+            status          TEXT NOT NULL,
+            ip              TEXT NOT NULL,
+            vsock_cid       INTEGER NOT NULL,
+            ch_pid          INTEGER,
+            ch_api_socket   TEXT NOT NULL,
+            ch_vsock_socket TEXT NOT NULL,
+            tap_device      TEXT NOT NULL,
+            mac_address     TEXT NOT NULL,
+            vcpus           INTEGER NOT NULL DEFAULT 2,
+            memory_mb       INTEGER NOT NULL DEFAULT 1024,
+            rootfs_path     TEXT NOT NULL,
+            created_at      TEXT NOT NULL,
+            stopped_at      TEXT
+        );",
+    )
+    .context("run migration")
+}
+
+/// Insert a new VM row (status = "creating").
+pub fn insert_vm(conn: &Connection, vm: &Vm) -> Result<()> {
+    conn.execute(
+        "INSERT INTO vms
+            (name, status, ip, vsock_cid, ch_pid, ch_api_socket, ch_vsock_socket,
+             tap_device, mac_address, vcpus, memory_mb, rootfs_path, created_at, stopped_at)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
+        params![
+            vm.name,
+            vm.status,
+            vm.ip,
+            vm.vsock_cid,
+            vm.ch_pid,
+            vm.ch_api_socket,
+            vm.ch_vsock_socket,
+            vm.tap_device,
+            vm.mac_address,
+            vm.vcpus,
+            vm.memory_mb,
+            vm.rootfs_path,
+            vm.created_at,
+            vm.stopped_at,
+        ],
+    )
+    .context("insert vm")?;
+    Ok(())
+}
+
+/// Retrieve a VM by name.
+pub fn get_vm(conn: &Connection, name: &str) -> Result<Option<Vm>> {
+    let mut stmt = conn.prepare(
+        "SELECT name,status,ip,vsock_cid,ch_pid,ch_api_socket,ch_vsock_socket,
+                tap_device,mac_address,vcpus,memory_mb,rootfs_path,created_at,stopped_at
+         FROM vms WHERE name=?1",
+    )?;
+    let mut rows = stmt.query(params![name])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(row_to_vm(row)?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// List all VMs.
+pub fn list_vms(conn: &Connection) -> Result<Vec<Vm>> {
+    let mut stmt = conn.prepare(
+        "SELECT name,status,ip,vsock_cid,ch_pid,ch_api_socket,ch_vsock_socket,
+                tap_device,mac_address,vcpus,memory_mb,rootfs_path,created_at,stopped_at
+         FROM vms ORDER BY created_at",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(row_to_vm(row).expect("parse vm row"))
+    })?;
+    Ok(rows.collect::<std::result::Result<_, _>>()?)
+}
+
+/// Update VM status and optionally pid.
+pub fn update_vm_status(conn: &Connection, name: &str, status: &str, pid: Option<i64>) -> Result<()> {
+    conn.execute(
+        "UPDATE vms SET status=?1, ch_pid=COALESCE(?2, ch_pid) WHERE name=?3",
+        params![status, pid, name],
+    )
+    .context("update vm status")?;
+    Ok(())
+}
+
+/// Delete a VM record.
+pub fn delete_vm(conn: &Connection, name: &str) -> Result<()> {
+    conn.execute("DELETE FROM vms WHERE name=?1", params![name])
+        .context("delete vm")?;
+    Ok(())
+}
+
+/// Pick the lowest available IP in 10.0.0.2..=10.0.0.254.
+pub fn next_available_ip(conn: &Connection) -> Result<String> {
+    let mut used: Vec<String> = conn
+        .prepare("SELECT ip FROM vms WHERE status != 'stopped'")?
+        .query_map([], |r| r.get(0))?
+        .collect::<std::result::Result<_, _>>()?;
+    used.sort();
+
+    for i in 2u32..=254 {
+        let candidate = format!("10.0.0.{i}");
+        if !used.contains(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!("IP pool exhausted")
+}
+
+/// Pick the lowest available VSOCK CID (3..=255).
+pub fn next_available_cid(conn: &Connection) -> Result<u32> {
+    let used: Vec<u32> = conn
+        .prepare("SELECT vsock_cid FROM vms WHERE status != 'stopped'")?
+        .query_map([], |r| r.get::<_, u32>(0))?
+        .collect::<std::result::Result<_, _>>()?;
+
+    for cid in 3u32..=255 {
+        if !used.contains(&cid) {
+            return Ok(cid);
+        }
+    }
+    anyhow::bail!("VSOCK CID pool exhausted")
+}
+
+fn row_to_vm(row: &rusqlite::Row<'_>) -> rusqlite::Result<Vm> {
+    Ok(Vm {
+        name: row.get(0)?,
+        status: row.get(1)?,
+        ip: row.get(2)?,
+        vsock_cid: row.get(3)?,
+        ch_pid: row.get(4)?,
+        ch_api_socket: row.get(5)?,
+        ch_vsock_socket: row.get(6)?,
+        tap_device: row.get(7)?,
+        mac_address: row.get(8)?,
+        vcpus: row.get(9)?,
+        memory_mb: row.get(10)?,
+        rootfs_path: row.get(11)?,
+        created_at: row.get(12)?,
+        stopped_at: row.get(13)?,
+    })
+}

--- a/crates/minions/src/hypervisor.rs
+++ b/crates/minions/src/hypervisor.rs
@@ -1,0 +1,149 @@
+//! Cloud-hypervisor process spawning and graceful shutdown.
+
+use anyhow::{Context, Result};
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+pub const KERNEL_PATH: &str = "/var/lib/minions/kernel/vmlinux";
+pub const RUN_DIR: &str = "/run/minions";
+
+pub struct VmConfig {
+    #[allow(dead_code)]
+    pub name: String,
+    pub vcpus: u32,
+    pub memory_mb: u32,
+    pub mac: String,
+    pub cid: u32,
+    pub rootfs: PathBuf,
+    pub tap: String,
+    pub api_socket: PathBuf,
+    pub vsock_socket: PathBuf,
+    pub serial_log: PathBuf,
+}
+
+/// Ensure /run/minions/ exists.
+pub fn ensure_run_dir() -> Result<()> {
+    std::fs::create_dir_all(RUN_DIR).context("create /run/minions")?;
+    Ok(())
+}
+
+pub fn api_socket_path(name: &str) -> PathBuf {
+    PathBuf::from(RUN_DIR).join(format!("{name}.sock"))
+}
+
+pub fn vsock_socket_path(name: &str) -> PathBuf {
+    PathBuf::from(RUN_DIR).join(format!("{name}.vsock"))
+}
+
+/// Spawn a cloud-hypervisor process detached from the parent.
+/// Returns the child PID.
+pub fn spawn(cfg: &VmConfig) -> Result<u32> {
+    // Safety: setsid() is safe to call in a single-threaded child context.
+    let mut cmd = Command::new("cloud-hypervisor");
+    cmd.args([
+        "--api-socket",
+        cfg.api_socket.to_str().unwrap(),
+        "--kernel",
+        KERNEL_PATH,
+        "--disk",
+        &format!("path={}", cfg.rootfs.display()),
+        "--cpus",
+        &format!("boot={}", cfg.vcpus),
+        "--memory",
+        &format!("size={}M", cfg.memory_mb),
+        "--net",
+        &format!("tap={},mac={}", cfg.tap, cfg.mac),
+        "--vsock",
+        &format!("cid={},socket={}", cfg.cid, cfg.vsock_socket.display()),
+        "--serial",
+        &format!("file={}", cfg.serial_log.display()),
+        "--console",
+        "off",
+        "--cmdline",
+        "console=ttyS0 root=/dev/vda rw quiet",
+    ])
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null());
+
+    // SAFETY: setsid() is async-signal-safe.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+
+    let child = cmd.spawn().context("spawn cloud-hypervisor")?;
+    Ok(child.id())
+}
+
+/// Gracefully shut down a VM via the CH API, falling back to SIGKILL.
+pub fn shutdown(name: &str, pid: Option<i64>) -> Result<()> {
+    let api_socket = api_socket_path(name);
+
+    if api_socket.exists() {
+        // Try graceful power button press.
+        let _ = curl_put(&api_socket.to_string_lossy(), "vm.power-button");
+        std::thread::sleep(Duration::from_secs(5));
+
+        // If still alive, force-shutdown VMM.
+        if is_alive_pid(pid) {
+            let _ = curl_put(&api_socket.to_string_lossy(), "vmm.shutdown");
+            std::thread::sleep(Duration::from_secs(2));
+        }
+    }
+
+    // Last resort: SIGKILL.
+    if is_alive_pid(pid) {
+        force_kill(pid);
+    }
+
+    // Clean up socket files.
+    let _ = std::fs::remove_file(&api_socket);
+    let vsock_socket = vsock_socket_path(name);
+    let _ = std::fs::remove_file(&vsock_socket);
+
+    Ok(())
+}
+
+/// Send a PUT request to the CH API via the Unix socket using curl.
+fn curl_put(socket: &str, endpoint: &str) -> Result<()> {
+    let status = Command::new("curl")
+        .args([
+            "-s",
+            "--unix-socket",
+            socket,
+            "-X",
+            "PUT",
+            &format!("http://localhost/api/v1/{endpoint}"),
+        ])
+        .status()
+        .context("curl CH API")?;
+    if !status.success() {
+        anyhow::bail!("curl PUT {endpoint} failed");
+    }
+    Ok(())
+}
+
+/// Check if a process is still alive.
+pub fn is_alive_pid(pid: Option<i64>) -> bool {
+    let Some(pid) = pid else { return false };
+    if pid <= 0 {
+        return false;
+    }
+    // kill -0 checks existence without sending a signal.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+/// Force-kill a process.
+pub fn force_kill(pid: Option<i64>) {
+    let Some(pid) = pid else { return };
+    if pid > 0 {
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+}

--- a/crates/minions/src/main.rs
+++ b/crates/minions/src/main.rs
@@ -1,0 +1,230 @@
+//! `minions` — VM lifecycle CLI for cloud-hypervisor guests.
+//!
+//! Must be run as root.
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use minions_proto::{Request, Response, ResponseData};
+use std::process::Command;
+use tabled::{Table, Tabled};
+
+mod agent;
+mod db;
+mod hypervisor;
+mod network;
+mod storage;
+mod vm;
+
+#[derive(Parser)]
+#[command(
+    name = "minions",
+    about = "VM lifecycle manager for cloud-hypervisor guests",
+    version
+)]
+struct Cli {
+    /// SQLite database path
+    #[arg(long, default_value = db::DB_PATH)]
+    db: String,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Create and start a new VM
+    Create {
+        /// VM name (alphanumeric + hyphens, max 11 chars)
+        name: String,
+
+        /// Number of vCPUs
+        #[arg(long, default_value_t = 2)]
+        cpus: u32,
+
+        /// Memory in MiB
+        #[arg(long, default_value_t = 1024)]
+        memory: u32,
+    },
+
+    /// Destroy a running VM
+    Destroy {
+        /// VM name
+        name: String,
+    },
+
+    /// List all VMs
+    List,
+
+    /// Run a command inside a VM
+    Exec {
+        /// VM name
+        name: String,
+
+        /// Command and arguments (after --)
+        #[arg(last = true)]
+        cmd: Vec<String>,
+    },
+
+    /// Open an interactive SSH session into a VM
+    Ssh {
+        /// VM name
+        name: String,
+    },
+
+    /// Show VM status (from agent)
+    Status {
+        /// VM name
+        name: String,
+    },
+
+    /// Print serial console log of a VM
+    Logs {
+        /// VM name
+        name: String,
+    },
+}
+
+#[derive(Tabled)]
+struct VmRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "STATUS")]
+    status: String,
+    #[tabled(rename = "IP")]
+    ip: String,
+    #[tabled(rename = "CPUS")]
+    cpus: u32,
+    #[tabled(rename = "MEMORY")]
+    memory: String,
+    #[tabled(rename = "PID")]
+    pid: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_target(false)
+        .with_level(true)
+        .init();
+
+    let cli = Cli::parse();
+    let conn = db::open(&cli.db).context("open state database")?;
+
+    match cli.command {
+        Commands::Create { name, cpus, memory } => {
+            println!("Creating VM '{name}'…");
+            let vm = vm::create(&conn, &name, cpus, memory).await?;
+            println!();
+            println!("✓ VM '{name}' is running");
+            println!("  IP:     {}", vm.ip);
+            println!("  CID:    {}", vm.vsock_cid);
+            println!("  CPUs:   {}", vm.vcpus);
+            println!("  Memory: {} MiB", vm.memory_mb);
+            println!("  PID:    {}", vm.ch_pid.unwrap_or(0));
+            println!();
+            println!("  SSH:    ssh root@{}", vm.ip);
+        }
+
+        Commands::Destroy { name } => {
+            println!("Destroying VM '{name}'…");
+            vm::destroy(&conn, &name).await?;
+            println!("✓ VM '{name}' destroyed");
+        }
+
+        Commands::List => {
+            let vms = vm::list(&conn)?;
+            if vms.is_empty() {
+                println!("No VMs found.");
+            } else {
+                let rows: Vec<VmRow> = vms
+                    .into_iter()
+                    .map(|v| VmRow {
+                        name: v.name,
+                        status: v.status,
+                        ip: v.ip,
+                        cpus: v.vcpus,
+                        memory: format!("{} MiB", v.memory_mb),
+                        pid: v
+                            .ch_pid
+                            .map(|p| p.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                    })
+                    .collect();
+                println!("{}", Table::new(rows));
+            }
+        }
+
+        Commands::Exec { name, cmd } => {
+            if cmd.is_empty() {
+                anyhow::bail!("provide a command after --");
+            }
+            let vm_rec = db::get_vm(&conn, &name)?
+                .with_context(|| format!("VM '{name}' not found"))?;
+
+            let vsock_socket = std::path::PathBuf::from(&vm_rec.ch_vsock_socket);
+            let response = agent::send_request(
+                &vsock_socket,
+                Request::Exec {
+                    command: cmd[0].clone(),
+                    args: cmd[1..].to_vec(),
+                },
+            )
+            .await?;
+
+            match response {
+                Response::Ok {
+                    data: Some(ResponseData::Exec { exit_code, stdout, stderr }),
+                    ..
+                } => {
+                    if !stdout.is_empty() {
+                        print!("{stdout}");
+                    }
+                    if !stderr.is_empty() {
+                        eprint!("{stderr}");
+                    }
+                    if exit_code != 0 {
+                        std::process::exit(exit_code);
+                    }
+                }
+                Response::Error { message } => anyhow::bail!("exec error: {message}"),
+                other => anyhow::bail!("unexpected response: {:?}", other),
+            }
+        }
+
+        Commands::Ssh { name } => {
+            let vm_rec = db::get_vm(&conn, &name)?
+                .with_context(|| format!("VM '{name}' not found"))?;
+            let status = Command::new("ssh")
+                .args([
+                    "-o",
+                    "StrictHostKeyChecking=no",
+                    "-o",
+                    "UserKnownHostsFile=/dev/null",
+                    &format!("root@{}", vm_rec.ip),
+                ])
+                .status()
+                .context("exec ssh")?;
+            std::process::exit(status.code().unwrap_or(1));
+        }
+
+        Commands::Status { name } => {
+            let vm_rec = db::get_vm(&conn, &name)?
+                .with_context(|| format!("VM '{name}' not found"))?;
+            let vsock_socket = std::path::PathBuf::from(&vm_rec.ch_vsock_socket);
+            let response =
+                agent::send_request(&vsock_socket, Request::ReportStatus).await?;
+            println!("{}", serde_json::to_string_pretty(&response)?);
+        }
+
+        Commands::Logs { name } => {
+            let log_path = storage::serial_log_path(&name);
+            if !log_path.exists() {
+                anyhow::bail!("no serial log found at {}", log_path.display());
+            }
+            let content = std::fs::read_to_string(&log_path)?;
+            print!("{content}");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/minions/src/network.rs
+++ b/crates/minions/src/network.rs
@@ -1,0 +1,74 @@
+//! TAP device management and MAC address generation.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+/// Create a TAP device, attach it to br0, and bring it up.
+pub fn create_tap(name: &str) -> Result<String> {
+    let tap = tap_name(name);
+
+    run("ip", &["tuntap", "add", "dev", &tap, "mode", "tap"])
+        .with_context(|| format!("create TAP {tap}"))?;
+
+    run("ip", &["link", "set", &tap, "master", "br0"])
+        .with_context(|| format!("attach {tap} to br0"))?;
+
+    run("ip", &["link", "set", &tap, "up"])
+        .with_context(|| format!("bring up {tap}"))?;
+
+    Ok(tap)
+}
+
+/// Delete a TAP device.
+pub fn destroy_tap(name: &str) -> Result<()> {
+    let tap = tap_name(name);
+    // Best-effort: ignore errors if device doesn't exist.
+    let _ = run("ip", &["link", "del", &tap]);
+    Ok(())
+}
+
+/// Verify that bridge br0 exists.
+pub fn check_bridge() -> Result<()> {
+    let output = Command::new("ip")
+        .args(["link", "show", "br0"])
+        .output()
+        .context("run ip link show br0")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "bridge br0 not found — run the Phase 1/2 host setup first.\n\
+             Hint: ip link add br0 type bridge && ip addr add 10.0.0.1/16 dev br0 && ip link set br0 up"
+        );
+    }
+    Ok(())
+}
+
+/// Generate a deterministic MAC address from a VSOCK CID.
+/// Format: `52:54:00:00:{cid_high}:{cid_low}`
+pub fn generate_mac(cid: u32) -> String {
+    let high = (cid >> 8) as u8;
+    let low = (cid & 0xff) as u8;
+    format!("52:54:00:00:{high:02x}:{low:02x}")
+}
+
+/// TAP device name derived from VM name (max 15 chars total).
+fn tap_name(name: &str) -> String {
+    let prefix = "tap-";
+    let max_suffix = 15 - prefix.len(); // 11
+    let suffix = if name.len() > max_suffix {
+        &name[..max_suffix]
+    } else {
+        name
+    };
+    format!("{prefix}{suffix}")
+}
+
+fn run(cmd: &str, args: &[&str]) -> Result<()> {
+    let status = Command::new(cmd)
+        .args(args)
+        .status()
+        .with_context(|| format!("spawn {cmd}"))?;
+    if !status.success() {
+        anyhow::bail!("{cmd} {} failed: {status}", args.join(" "));
+    }
+    Ok(())
+}

--- a/crates/minions/src/storage.rs
+++ b/crates/minions/src/storage.rs
@@ -1,0 +1,58 @@
+//! Rootfs management: copy base image per VM, clean up on destroy.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+pub const BASE_IMAGE: &str = "/var/lib/minions/images/base-ubuntu.ext4";
+pub const VMS_DIR: &str = "/var/lib/minions/vms";
+
+/// Return the rootfs path for a given VM name.
+#[allow(dead_code)]
+pub fn rootfs_path(name: &str) -> PathBuf {
+    PathBuf::from(VMS_DIR).join(name).join("rootfs.ext4")
+}
+
+/// Copy the base image to a per-VM rootfs.
+/// The base image must already contain the minions-agent binary + systemd unit.
+pub fn create_rootfs(name: &str) -> Result<PathBuf> {
+    let vm_dir = PathBuf::from(VMS_DIR).join(name);
+    std::fs::create_dir_all(&vm_dir)
+        .with_context(|| format!("create VM dir {:?}", vm_dir))?;
+
+    let dst = vm_dir.join("rootfs.ext4");
+    let base = Path::new(BASE_IMAGE);
+
+    if !base.exists() {
+        anyhow::bail!(
+            "base image not found at {BASE_IMAGE}\n\
+             Build it first with the Phase 1/2 setup scripts."
+        );
+    }
+
+    // Use `cp --sparse=always` for a fast copy that preserves sparse blocks.
+    let status = std::process::Command::new("cp")
+        .args(["--sparse=always", BASE_IMAGE, dst.to_str().unwrap()])
+        .status()
+        .context("spawn cp")?;
+
+    if !status.success() {
+        anyhow::bail!("cp base image failed");
+    }
+
+    Ok(dst)
+}
+
+/// Remove the per-VM directory and all its contents.
+pub fn destroy_rootfs(name: &str) -> Result<()> {
+    let vm_dir = PathBuf::from(VMS_DIR).join(name);
+    if vm_dir.exists() {
+        std::fs::remove_dir_all(&vm_dir)
+            .with_context(|| format!("remove {:?}", vm_dir))?;
+    }
+    Ok(())
+}
+
+/// Path to the serial log for a VM.
+pub fn serial_log_path(name: &str) -> PathBuf {
+    PathBuf::from(VMS_DIR).join(name).join("serial.log")
+}

--- a/crates/minions/src/vm.rs
+++ b/crates/minions/src/vm.rs
@@ -1,0 +1,146 @@
+//! VM lifecycle orchestration: create, destroy, list, status.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use rusqlite::Connection;
+use std::time::Duration;
+use tracing::info;
+
+use crate::{agent, db, hypervisor, network, storage};
+
+/// Create a fully networked VM.
+pub async fn create(conn: &Connection, name: &str, vcpus: u32, memory_mb: u32) -> Result<db::Vm> {
+    validate_name(name)?;
+
+    if db::get_vm(conn, name)?.is_some() {
+        anyhow::bail!("VM '{name}' already exists");
+    }
+
+    network::check_bridge().context("bridge check")?;
+    hypervisor::ensure_run_dir()?;
+
+    // Allocate resources.
+    let ip = db::next_available_ip(conn)?;
+    let cid = db::next_available_cid(conn)?;
+    let mac = network::generate_mac(cid);
+    let tap = network::create_tap(name).context("create TAP device")?;
+    let rootfs = storage::create_rootfs(name).context("copy base rootfs")?;
+
+    let api_socket = hypervisor::api_socket_path(name);
+    let vsock_socket = hypervisor::vsock_socket_path(name);
+    let serial_log = storage::serial_log_path(name);
+
+    let vm = db::Vm {
+        name: name.to_string(),
+        status: "creating".to_string(),
+        ip: ip.clone(),
+        vsock_cid: cid,
+        ch_pid: None,
+        ch_api_socket: api_socket.to_string_lossy().to_string(),
+        ch_vsock_socket: vsock_socket.to_string_lossy().to_string(),
+        tap_device: tap.clone(),
+        mac_address: mac.clone(),
+        vcpus,
+        memory_mb,
+        rootfs_path: rootfs.to_string_lossy().to_string(),
+        created_at: Utc::now().to_rfc3339(),
+        stopped_at: None,
+    };
+
+    db::insert_vm(conn, &vm).context("insert VM into DB")?;
+
+    // Spawn cloud-hypervisor.
+    let cfg = hypervisor::VmConfig {
+        name: name.to_string(),
+        vcpus,
+        memory_mb,
+        mac,
+        cid,
+        rootfs: rootfs.clone(),
+        tap,
+        api_socket: api_socket.clone(),
+        vsock_socket: vsock_socket.clone(),
+        serial_log,
+    };
+
+    let pid = hypervisor::spawn(&cfg).context("spawn cloud-hypervisor")?;
+    info!("cloud-hypervisor PID={pid}");
+
+    db::update_vm_status(conn, name, "starting", Some(pid as i64))
+        .context("update VM status to starting")?;
+
+    // Wait for agent to be ready (up to 60 seconds).
+    info!("waiting for agent to become ready…");
+    agent::wait_ready(&vsock_socket, Duration::from_secs(60))
+        .await
+        .context("wait for agent ready")?;
+
+    info!("agent ready, configuring network");
+
+    // Configure guest networking.
+    agent::configure_network(
+        &vsock_socket,
+        &format!("{ip}/16"),
+        "10.0.0.1",
+        vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()],
+    )
+    .await
+    .context("configure guest network")?;
+
+    db::update_vm_status(conn, name, "running", None).context("update VM status to running")?;
+
+    let vm = db::get_vm(conn, name)?.expect("VM just inserted");
+    Ok(vm)
+}
+
+/// Destroy a VM: shutdown CH, delete TAP, delete rootfs, remove DB row.
+pub async fn destroy(conn: &Connection, name: &str) -> Result<()> {
+    let vm = db::get_vm(conn, name)?
+        .with_context(|| format!("VM '{name}' not found"))?;
+
+    db::update_vm_status(conn, name, "stopping", None)?;
+
+    // Graceful CH shutdown.
+    hypervisor::shutdown(name, vm.ch_pid).context("shutdown hypervisor")?;
+
+    // Tear down networking.
+    network::destroy_tap(name).context("destroy TAP")?;
+
+    // Remove rootfs.
+    storage::destroy_rootfs(name).context("destroy rootfs")?;
+
+    // Remove DB record.
+    db::delete_vm(conn, name)?;
+
+    Ok(())
+}
+
+/// List all VMs, correcting stale "running" status for dead processes.
+pub fn list(conn: &Connection) -> Result<Vec<db::Vm>> {
+    let mut vms = db::list_vms(conn)?;
+
+    for vm in &mut vms {
+        if vm.status == "running" && !hypervisor::is_alive_pid(vm.ch_pid) {
+            vm.status = "error (process dead)".to_string();
+            let _ = db::update_vm_status(conn, &vm.name, "error", None);
+        }
+    }
+
+    Ok(vms)
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("VM name cannot be empty");
+    }
+    if name.len() > 11 {
+        anyhow::bail!("VM name must be 11 characters or fewer (TAP device limit)");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-')
+    {
+        anyhow::bail!("VM name must only contain alphanumeric characters and hyphens");
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #2

## What's in this PR

Implements the full VM lifecycle orchestration described in issue #2.

### New crate: `crates/minions`

| File | Purpose |
|------|---------|
| `src/main.rs` | `clap` CLI — `create / destroy / list / exec / ssh / status / logs` |
| `src/vm.rs` | Orchestrate create + destroy flows |
| `src/hypervisor.rs` | Detached CH spawn (`setsid`) + graceful shutdown via `curl` |
| `src/network.rs` | TAP create/destroy, deterministic MAC generation |
| `src/storage.rs` | Base image copy (`cp --sparse=always`), serial log path |
| `src/agent.rs` | VSOCK connect+handshake, `wait_ready` (exponential backoff), `send_request` |
| `src/db.rs` | SQLite (WAL), schema migration, CRUD, IP pool, CID pool |

### Create flow

1. Validate name → allocate IP + VSOCK CID → generate MAC
2. Copy base rootfs (`cp --sparse=always`)
3. Create TAP device + attach to `br0`
4. Insert DB row (status: `creating`)
5. Spawn `cloud-hypervisor` detached (`setsid`)
6. `wait_ready` — exponential backoff until agent health check passes (30 s timeout)
7. `configure_network` via agent VSOCK
8. Update DB → `running`

### Destroy flow

1. Graceful CH shutdown (PUT `/api/v1/vm.power-button`, 5 s wait, force if needed)
2. Delete TAP device
3. Remove per-VM rootfs directory
4. Delete DB row

### Other commands

- **`list`** — table view with live process-liveness check (marks stale entries as `error`)
- **`exec`** — forwards command to agent, streams stdout/stderr, exits with agent's exit code
- **`ssh`** — `exec ssh -o StrictHostKeyChecking=no root@{ip}`
- **`status`** — agent `ReportStatus` response as JSON
- **`logs`** — print `/var/lib/minions/vms/{name}/serial.log`

### Other changes

- `Cargo.toml` — added `crates/minions` to workspace members
- `docs/phase-3-setup.md` — one-time host setup + usage guide