### PR TITLE
feat: Phase 4 — HTTP API + daemon mode

### DIFF
--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -21,3 +21,8 @@ nix = { version = "0.30", features = ["signal"] }
 libc = "0.2"
 chrono = "0.4"
 tabled = "0.17"
+# HTTP API (daemon)
+axum = "0.8"
+tower-http = { version = "0.6", features = ["trace", "cors"] }
+# HTTP client (CLI remote mode)
+reqwest = { version = "0.12", features = ["json"] }

--- a/crates/minions/src/api.rs
+++ b/crates/minions/src/api.rs
@@ -1,0 +1,288 @@
+//! HTTP API routes (axum).
+//!
+//! All responses are JSON. Errors use standard HTTP status codes.
+//! Each handler opens its own SQLite connection (WAL mode → safe concurrent reads).
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+};
+use serde::{Deserialize, Serialize};
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+use tracing::info;
+
+use crate::{agent, db, server::AppState, storage, vm};
+use minions_proto::{Request as AgentRequest, Response as AgentResponse, ResponseData};
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/vms", post(create_vm))
+        .route("/api/vms", get(list_vms))
+        .route("/api/vms/:name", get(get_vm))
+        .route("/api/vms/:name", delete(destroy_vm))
+        .route("/api/vms/:name/exec", post(exec_vm))
+        .route("/api/vms/:name/status", get(vm_status))
+        .route("/api/vms/:name/logs", get(vm_logs))
+        .layer(CorsLayer::permissive())
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRequest {
+    pub name: String,
+    #[serde(default = "default_cpus")]
+    pub cpus: u32,
+    #[serde(default = "default_memory")]
+    pub memory_mb: u32,
+}
+
+fn default_cpus() -> u32 { 2 }
+fn default_memory() -> u32 { 1024 }
+
+#[derive(Debug, Serialize)]
+pub struct VmResponse {
+    pub name: String,
+    pub status: String,
+    pub ip: String,
+    pub vsock_cid: u32,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub pid: Option<i64>,
+    pub created_at: String,
+}
+
+impl From<db::Vm> for VmResponse {
+    fn from(v: db::Vm) -> Self {
+        VmResponse {
+            name: v.name,
+            status: v.status,
+            ip: v.ip,
+            vsock_cid: v.vsock_cid,
+            cpus: v.vcpus,
+            memory_mb: v.memory_mb,
+            pid: v.ch_pid,
+            created_at: v.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExecRequest {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExecResponse {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+// ── Error helpers ─────────────────────────────────────────────────────────────
+
+fn internal(e: impl std::fmt::Display) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse { error: e.to_string() }),
+    )
+}
+
+fn not_found(name: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse { error: format!("VM '{name}' not found") }),
+    )
+}
+
+fn bad_request(msg: impl std::fmt::Display) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse { error: msg.to_string() }),
+    )
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `POST /api/vms` — Create a VM.
+async fn create_vm(
+    State(state): State<AppState>,
+    Json(req): Json<CreateRequest>,
+) -> impl IntoResponse {
+    info!(name = %req.name, cpus = req.cpus, memory_mb = req.memory_mb, "create VM");
+
+    let ssh_pubkey = state.ssh_pubkey.as_deref().map(|s| s.to_string());
+    let db_path = state.db_path.as_str().to_string();
+
+    match vm::create(&db_path, &req.name, req.cpus, req.memory_mb, ssh_pubkey).await {
+        Ok(v) => (StatusCode::CREATED, Json(VmResponse::from(v))).into_response(),
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("already exists") {
+                bad_request(msg).into_response()
+            } else {
+                internal(msg).into_response()
+            }
+        }
+    }
+}
+
+/// `GET /api/vms` — List all VMs.
+async fn list_vms(State(state): State<AppState>) -> impl IntoResponse {
+    let conn = match db::open(&state.db_path) {
+        Ok(c) => c,
+        Err(e) => return internal(e).into_response(),
+    };
+
+    match vm::list(&conn) {
+        Ok(vms) => {
+            let resp: Vec<VmResponse> = vms.into_iter().map(VmResponse::from).collect();
+            Json(resp).into_response()
+        }
+        Err(e) => internal(e).into_response(),
+    }
+}
+
+/// `GET /api/vms/:name` — Get VM details.
+async fn get_vm(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let conn = match db::open(&state.db_path) {
+        Ok(c) => c,
+        Err(e) => return internal(e).into_response(),
+    };
+
+    match db::get_vm(&conn, &name) {
+        Ok(Some(v)) => Json(VmResponse::from(v)).into_response(),
+        Ok(None) => not_found(&name).into_response(),
+        Err(e) => internal(e).into_response(),
+    }
+}
+
+/// `DELETE /api/vms/:name` — Destroy a VM.
+async fn destroy_vm(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    info!(name = %name, "destroy VM");
+
+    // Check VM exists (sync, connection dropped before await).
+    {
+        let conn = match db::open(&state.db_path) {
+            Ok(c) => c,
+            Err(e) => return internal(e).into_response(),
+        };
+        match db::get_vm(&conn, &name) {
+            Ok(None) => return not_found(&name).into_response(),
+            Err(e) => return internal(e).into_response(),
+            Ok(Some(_)) => {}
+        }
+    } // conn dropped here
+
+    let db_path = state.db_path.as_str().to_string();
+    match vm::destroy(&db_path, &name).await {
+        Ok(()) => Json(serde_json::json!({ "message": format!("VM '{name}' destroyed") }))
+            .into_response(),
+        Err(e) => internal(e).into_response(),
+    }
+}
+
+/// `POST /api/vms/:name/exec` — Execute a command inside the VM.
+async fn exec_vm(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<ExecRequest>,
+) -> impl IntoResponse {
+    // Sync: look up VM, then drop connection before await.
+    let vsock_socket = {
+        let conn = match db::open(&state.db_path) {
+            Ok(c) => c,
+            Err(e) => return internal(e).into_response(),
+        };
+        match db::get_vm(&conn, &name) {
+            Ok(Some(v)) => std::path::PathBuf::from(v.ch_vsock_socket),
+            Ok(None) => return not_found(&name).into_response(),
+            Err(e) => return internal(e).into_response(),
+        }
+    }; // conn dropped
+
+    let response = match agent::send_request(
+        &vsock_socket,
+        AgentRequest::Exec { command: req.command, args: req.args },
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return internal(e).into_response(),
+    };
+
+    match response {
+        AgentResponse::Ok {
+            data: Some(ResponseData::Exec { exit_code, stdout, stderr }),
+            ..
+        } => Json(ExecResponse { exit_code, stdout, stderr }).into_response(),
+        AgentResponse::Error { message } => internal(message).into_response(),
+        other => internal(format!("unexpected response: {other:?}")).into_response(),
+    }
+}
+
+/// `GET /api/vms/:name/status` — Agent status.
+async fn vm_status(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Sync: look up VM, then drop connection before await.
+    let vsock_socket = {
+        let conn = match db::open(&state.db_path) {
+            Ok(c) => c,
+            Err(e) => return internal(e).into_response(),
+        };
+        match db::get_vm(&conn, &name) {
+            Ok(Some(v)) => std::path::PathBuf::from(v.ch_vsock_socket),
+            Ok(None) => return not_found(&name).into_response(),
+            Err(e) => return internal(e).into_response(),
+        }
+    }; // conn dropped
+
+    match agent::send_request(&vsock_socket, AgentRequest::ReportStatus).await {
+        Ok(r) => Json(r).into_response(),
+        Err(e) => internal(e).into_response(),
+    }
+}
+
+/// `GET /api/vms/:name/logs` — Serial console log.
+async fn vm_logs(
+    State(_state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let log_path = storage::serial_log_path(&name);
+    match std::fs::read_to_string(&log_path) {
+        Ok(content) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            content,
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse { error: format!("no logs found for VM '{name}'") }),
+        )
+            .into_response(),
+    }
+}

--- a/crates/minions/src/client.rs
+++ b/crates/minions/src/client.rs
@@ -1,0 +1,147 @@
+//! HTTP client for the remote CLI mode.
+//!
+//! When `--host` is given, the CLI sends requests to the minions daemon
+//! instead of orchestrating VMs directly.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+pub struct CreateRequest {
+    pub name: String,
+    pub cpus: u32,
+    pub memory_mb: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VmResponse {
+    pub name: String,
+    pub status: String,
+    pub ip: String,
+    pub vsock_cid: u32,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub pid: Option<i64>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExecRequest {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExecResponse {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct Client {
+    http: reqwest::Client,
+    base: String,
+}
+
+impl Client {
+    pub fn new(host: &str) -> Self {
+        let base = host.trim_end_matches('/').to_string();
+        Client {
+            http: reqwest::Client::new(),
+            base,
+        }
+    }
+
+    pub async fn create_vm(&self, req: CreateRequest) -> Result<VmResponse> {
+        self.http
+            .post(format!("{}/api/vms", self.base))
+            .json(&req)
+            .send()
+            .await
+            .context("send create request")?
+            .error_for_status()
+            .context("create VM")?
+            .json()
+            .await
+            .context("decode create response")
+    }
+
+    pub async fn list_vms(&self) -> Result<Vec<VmResponse>> {
+        self.http
+            .get(format!("{}/api/vms", self.base))
+            .send()
+            .await
+            .context("send list request")?
+            .error_for_status()
+            .context("list VMs")?
+            .json()
+            .await
+            .context("decode list response")
+    }
+
+    pub async fn destroy_vm(&self, name: &str) -> Result<()> {
+        self.http
+            .delete(format!("{}/api/vms/{name}", self.base))
+            .send()
+            .await
+            .context("send destroy request")?
+            .error_for_status()
+            .context("destroy VM")?;
+        Ok(())
+    }
+
+    pub async fn exec_vm(&self, name: &str, req: ExecRequest) -> Result<ExecResponse> {
+        self.http
+            .post(format!("{}/api/vms/{name}/exec", self.base))
+            .json(&req)
+            .send()
+            .await
+            .context("send exec request")?
+            .error_for_status()
+            .context("exec in VM")?
+            .json()
+            .await
+            .context("decode exec response")
+    }
+
+    pub async fn vm_status(&self, name: &str) -> Result<serde_json::Value> {
+        self.http
+            .get(format!("{}/api/vms/{name}/status", self.base))
+            .send()
+            .await
+            .context("send status request")?
+            .error_for_status()
+            .context("VM status")?
+            .json()
+            .await
+            .context("decode status response")
+    }
+
+    pub async fn vm_logs(&self, name: &str) -> Result<String> {
+        self.http
+            .get(format!("{}/api/vms/{name}/logs", self.base))
+            .send()
+            .await
+            .context("send logs request")?
+            .error_for_status()
+            .context("VM logs")?
+            .text()
+            .await
+            .context("decode logs response")
+    }
+}
+
+/// Check if the local daemon is reachable on port 3000.
+pub async fn local_daemon_url() -> Option<String> {
+    let url = "http://127.0.0.1:3000";
+    let client = reqwest::Client::new();
+    match tokio::time::timeout(
+        std::time::Duration::from_millis(200),
+        client.get(format!("{url}/api/vms")).send(),
+    )
+    .await
+    {
+        Ok(Ok(_)) => Some(url.to_string()),
+        _ => None,
+    }
+}

--- a/crates/minions/src/init.rs
+++ b/crates/minions/src/init.rs
@@ -1,0 +1,257 @@
+//! Host setup automation: bridge, iptables, directories, systemd unit.
+//!
+//! All operations are idempotent — safe to run multiple times.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+const SYSTEMD_UNIT_PATH: &str = "/etc/systemd/system/minions.service";
+const SYSCTL_FORWARD: &str = "/proc/sys/net/ipv4/ip_forward";
+
+pub fn run(persist: bool) -> Result<()> {
+    check_kvm()?;
+    setup_directories()?;
+    setup_bridge()?;
+    enable_ip_forward(persist)?;
+    setup_iptables(persist)?;
+    install_systemd_unit()?;
+
+    println!();
+    println!("────────────────────────────────────────────");
+    ok("Host setup complete!");
+    println!();
+    println!("  Next steps:");
+    println!("    1. Copy base image:   /var/lib/minions/images/base-ubuntu.ext4");
+    println!("    2. Copy kernel:       /var/lib/minions/kernel/vmlinux");
+    println!("    3. Bake the agent:    sudo ./scripts/bake-agent.sh");
+    println!("    4. Start the daemon:  sudo systemctl enable --now minions");
+    println!("    5. Create a VM:       sudo minions create myvm");
+    println!("────────────────────────────────────────────");
+
+    Ok(())
+}
+
+// ── KVM ───────────────────────────────────────────────────────────────────────
+
+fn check_kvm() -> Result<()> {
+    info("checking KVM availability");
+    if !std::path::Path::new("/dev/kvm").exists() {
+        anyhow::bail!(
+            "/dev/kvm not found.\n\
+             Ensure KVM is enabled: lsmod | grep kvm\n\
+             On AMD: kvm_amd, on Intel: kvm_intel"
+        );
+    }
+    ok("KVM available");
+    Ok(())
+}
+
+// ── Directories ───────────────────────────────────────────────────────────────
+
+fn setup_directories() -> Result<()> {
+    info("creating directories");
+    for dir in &[
+        "/var/lib/minions/kernel",
+        "/var/lib/minions/images",
+        "/var/lib/minions/vms",
+        "/run/minions",
+    ] {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("create {dir}"))?;
+    }
+    ok("directories ready");
+    Ok(())
+}
+
+// ── Bridge ────────────────────────────────────────────────────────────────────
+
+fn setup_bridge() -> Result<()> {
+    info("setting up bridge br0");
+
+    // Check if br0 already exists.
+    let out = Command::new("ip")
+        .args(["link", "show", "br0"])
+        .output()
+        .context("ip link show br0")?;
+
+    if out.status.success() {
+        ok("bridge br0 already exists — skipping");
+        return Ok(());
+    }
+
+    exec_cmd("ip", &["link", "add", "br0", "type", "bridge"])?;
+    exec_cmd("ip", &["addr", "add", "10.0.0.1/16", "dev", "br0"])?;
+    exec_cmd("ip", &["link", "set", "br0", "up"])?;
+    ok("bridge br0 created at 10.0.0.1/16");
+    Ok(())
+}
+
+// ── IP forwarding ─────────────────────────────────────────────────────────────
+
+fn enable_ip_forward(persist: bool) -> Result<()> {
+    info("enabling IP forwarding");
+    std::fs::write(SYSCTL_FORWARD, "1\n").context("write ip_forward")?;
+    ok("ip_forward = 1");
+
+    if persist {
+        // Write a sysctl drop-in so it survives reboots.
+        std::fs::create_dir_all("/etc/sysctl.d")?;
+        std::fs::write(
+            "/etc/sysctl.d/99-minions.conf",
+            "net.ipv4.ip_forward = 1\n",
+        )
+        .context("write sysctl drop-in")?;
+        ok("ip_forward persisted via /etc/sysctl.d/99-minions.conf");
+    }
+
+    Ok(())
+}
+
+// ── iptables ─────────────────────────────────────────────────────────────────
+
+fn setup_iptables(persist: bool) -> Result<()> {
+    info("setting up iptables rules");
+
+    let main_if = detect_main_interface()?;
+
+    // Rules to add: (table, chain, args...)
+    let nat_rule: &[&str] = &[
+        "-t", "nat", "-A", "POSTROUTING",
+        "-s", "10.0.0.0/16",
+        "-o", &main_if,
+        "-j", "MASQUERADE",
+    ];
+    let fwd_out: &[&str] = &[
+        "-I", "FORWARD",
+        "-i", "br0", "-o", &main_if,
+        "-j", "ACCEPT",
+    ];
+    let fwd_in: &[&str] = &[
+        "-I", "FORWARD",
+        "-i", &main_if, "-o", "br0",
+        "-m", "state", "--state", "RELATED,ESTABLISHED",
+        "-j", "ACCEPT",
+    ];
+    let fwd_vm2vm: &[&str] = &[
+        "-I", "FORWARD",
+        "-i", "br0", "-o", "br0",
+        "-j", "ACCEPT",
+    ];
+
+    for rule in &[nat_rule, fwd_out, fwd_in, fwd_vm2vm] {
+        add_iptables_rule(rule)?;
+    }
+    ok("iptables rules added");
+
+    if persist {
+        // Install iptables-persistent and save rules.
+        let _ = Command::new("apt-get")
+            .args(["install", "-y", "-q", "iptables-persistent"])
+            .status();
+        let _ = Command::new("sh")
+            .arg("-c")
+            .arg("iptables-save > /etc/iptables/rules.v4")
+            .status();
+        ok("iptables rules persisted via iptables-persistent");
+    }
+
+    Ok(())
+}
+
+/// Add an iptables rule, skipping if it already exists.
+fn add_iptables_rule(args: &[&str]) -> Result<()> {
+    // Build check args: replace -A/-I with -C.
+    let check_args: Vec<&str> = args
+        .iter()
+        .map(|a| match *a {
+            "-A" | "-I" => "-C",
+            other => other,
+        })
+        .collect();
+
+    let exists = Command::new("iptables")
+        .args(&check_args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if exists {
+        return Ok(());
+    }
+
+    exec_cmd("iptables", args)?;
+    Ok(())
+}
+
+fn detect_main_interface() -> Result<String> {
+    let out = Command::new("ip")
+        .args(["route", "show", "default"])
+        .output()
+        .context("ip route show default")?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for word in stdout.split_whitespace().collect::<Vec<_>>().windows(2) {
+        if word[0] == "dev" {
+            return Ok(word[1].to_string());
+        }
+    }
+    anyhow::bail!("could not detect default network interface")
+}
+
+// ── Systemd unit ──────────────────────────────────────────────────────────────
+
+fn install_systemd_unit() -> Result<()> {
+    info("installing minions.service systemd unit");
+
+    let unit = r#"[Unit]
+Description=Minions VM Manager Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/minions serve
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+"#;
+
+    std::fs::write(SYSTEMD_UNIT_PATH, unit)
+        .with_context(|| format!("write {SYSTEMD_UNIT_PATH}"))?;
+
+    // Reload systemd so the new unit is visible.
+    let _ = Command::new("systemctl")
+        .args(["daemon-reload"])
+        .status();
+
+    ok(format!(
+        "systemd unit installed at {SYSTEMD_UNIT_PATH}\n  \
+         Enable with: sudo systemctl enable --now minions"
+    ));
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn exec_cmd(cmd: &str, args: &[&str]) -> Result<()> {
+    let status = Command::new(cmd)
+        .args(args)
+        .status()
+        .with_context(|| format!("spawn {cmd}"))?;
+    if !status.success() {
+        anyhow::bail!("{cmd} {} exited with {status}", args.join(" "));
+    }
+    Ok(())
+}
+
+fn info(msg: &str) {
+    println!("  [init] {msg}…");
+}
+
+fn ok(msg: impl std::fmt::Display) {
+    println!("✓ {msg}");
+}

--- a/crates/minions/src/server.rs
+++ b/crates/minions/src/server.rs
@@ -1,0 +1,106 @@
+//! Daemon mode: startup reconciliation + HTTP server.
+
+use anyhow::Result;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::{api, db, hypervisor, network};
+
+/// Shared state passed to every HTTP handler.
+#[derive(Clone)]
+pub struct AppState {
+    /// Path to the SQLite database (each handler opens its own connection).
+    pub db_path: Arc<String>,
+    /// SSH public key to inject into new VMs.
+    pub ssh_pubkey: Option<Arc<String>>,
+}
+
+/// Reconcile DB state with reality.
+///
+/// Called once on daemon startup to handle VMs that died while the daemon
+/// was offline (host reboot, crash, OOM kill).
+pub fn reconcile(db_path: &str) -> Result<()> {
+    info!("reconciling VM state…");
+    let conn = db::open(db_path)?;
+    let vms = db::list_vms(&conn)?;
+
+    for vm in &vms {
+        match vm.status.as_str() {
+            "running" | "starting" | "creating" | "stopping" => {
+                if !hypervisor::is_alive_pid(vm.ch_pid) {
+                    warn!(
+                        name = %vm.name,
+                        status = %vm.status,
+                        "CH process dead — marking stopped and cleaning up"
+                    );
+                    // Best-effort cleanup.
+                    let _ = network::destroy_tap(&vm.name);
+                    for sock in [&vm.ch_api_socket, &vm.ch_vsock_socket] {
+                        let _ = std::fs::remove_file(sock);
+                    }
+                    let _ = db::update_vm_status(&conn, &vm.name, "stopped", None);
+                } else {
+                    info!(name = %vm.name, "VM alive ✓");
+                }
+            }
+            _ => {} // stopped / error — nothing to do
+        }
+    }
+
+    // Clean up orphan socket files in /run/minions/ with no DB entry.
+    cleanup_orphan_sockets(&conn)?;
+
+    info!("reconciliation complete");
+    Ok(())
+}
+
+fn cleanup_orphan_sockets(conn: &rusqlite::Connection) -> Result<()> {
+    let run_dir = std::path::Path::new(hypervisor::RUN_DIR);
+    if !run_dir.exists() {
+        return Ok(());
+    }
+
+    let vms = db::list_vms(conn)?;
+    let known_names: std::collections::HashSet<String> =
+        vms.into_iter().map(|v| v.name).collect();
+
+    for entry in std::fs::read_dir(run_dir)? {
+        let entry = entry?;
+        let fname = entry.file_name();
+        let fname = fname.to_string_lossy();
+
+        // Socket files look like "{name}.sock" or "{name}.vsock"
+        let vm_name = fname
+            .strip_suffix(".sock")
+            .or_else(|| fname.strip_suffix(".vsock"));
+
+        if let Some(name) = vm_name {
+            if !known_names.contains(name) {
+                warn!("orphan socket {:?} — removing", entry.path());
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Start the HTTP API daemon.
+pub async fn serve(db_path: String, bind: String, ssh_pubkey: Option<String>) -> Result<()> {
+    reconcile(&db_path)?;
+
+    let state = AppState {
+        db_path: Arc::new(db_path),
+        ssh_pubkey: ssh_pubkey.map(Arc::new),
+    };
+
+    let app = api::router(state);
+
+    let listener = tokio::net::TcpListener::bind(&bind)
+        .await
+        .map_err(|e| anyhow::anyhow!("bind {bind}: {e}"))?;
+
+    info!("minions daemon listening on http://{bind}");
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/crates/minions/src/vm.rs
+++ b/crates/minions/src/vm.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use chrono::Utc;
-use rusqlite::Connection;
 use std::time::Duration;
 use tracing::info;
 
@@ -12,150 +11,171 @@ use crate::{agent, db, hypervisor, network, storage};
 
 /// Create a fully networked VM.
 ///
-/// `ssh_pubkey`: if Some, injected into `/root/.ssh/authorized_keys` inside the
-/// VM so that `minions ssh` works without a password.
+/// Takes `db_path` instead of `&Connection` so the connection is never held
+/// across `.await` points (rusqlite::Connection is !Sync).
 pub async fn create(
-    conn: &Connection,
+    db_path: &str,
     name: &str,
     vcpus: u32,
     memory_mb: u32,
     ssh_pubkey: Option<String>,
 ) -> Result<db::Vm> {
-    validate_name(name)?;
+    // ── Sync: validate + allocate resources ──────────────────────────────────
+    let (ip, vsock_socket, cfg) = {
+        let conn = db::open(db_path)?;
+        validate_name(name)?;
+        if db::get_vm(&conn, name)?.is_some() {
+            anyhow::bail!("VM '{name}' already exists");
+        }
+        network::check_bridge().context("bridge check")?;
+        hypervisor::ensure_run_dir()?;
 
-    if db::get_vm(conn, name)?.is_some() {
-        anyhow::bail!("VM '{name}' already exists");
-    }
+        let ip = db::next_available_ip(&conn)?;
+        let cid = db::next_available_cid(&conn)?;
+        let mac = network::generate_mac(cid);
+        let tap = network::create_tap(name).context("create TAP device")?;
+        let rootfs = storage::create_rootfs(name).context("copy base rootfs")?;
 
-    network::check_bridge().context("bridge check")?;
-    hypervisor::ensure_run_dir()?;
+        let api_socket = hypervisor::api_socket_path(name);
+        let vsock_socket = hypervisor::vsock_socket_path(name);
+        let serial_log = storage::serial_log_path(name);
 
-    // Allocate resources.
-    let ip = db::next_available_ip(conn)?;
-    let cid = db::next_available_cid(conn)?;
-    let mac = network::generate_mac(cid);
-    let tap = network::create_tap(name).context("create TAP device")?;
-    let rootfs = storage::create_rootfs(name).context("copy base rootfs")?;
+        let vm_row = db::Vm {
+            name: name.to_string(),
+            status: "creating".to_string(),
+            ip: ip.clone(),
+            vsock_cid: cid,
+            ch_pid: None,
+            ch_api_socket: api_socket.to_string_lossy().to_string(),
+            ch_vsock_socket: vsock_socket.to_string_lossy().to_string(),
+            tap_device: tap.clone(),
+            mac_address: mac.clone(),
+            vcpus,
+            memory_mb,
+            rootfs_path: rootfs.to_string_lossy().to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            stopped_at: None,
+        };
+        db::insert_vm(&conn, &vm_row).context("insert VM into DB")?;
 
-    let api_socket = hypervisor::api_socket_path(name);
-    let vsock_socket = hypervisor::vsock_socket_path(name);
-    let serial_log = storage::serial_log_path(name);
-
-    let vm = db::Vm {
-        name: name.to_string(),
-        status: "creating".to_string(),
-        ip: ip.clone(),
-        vsock_cid: cid,
-        ch_pid: None,
-        ch_api_socket: api_socket.to_string_lossy().to_string(),
-        ch_vsock_socket: vsock_socket.to_string_lossy().to_string(),
-        tap_device: tap.clone(),
-        mac_address: mac.clone(),
-        vcpus,
-        memory_mb,
-        rootfs_path: rootfs.to_string_lossy().to_string(),
-        created_at: Utc::now().to_rfc3339(),
-        stopped_at: None,
+        let cfg = hypervisor::VmConfig {
+            name: name.to_string(),
+            vcpus,
+            memory_mb,
+            mac,
+            cid,
+            rootfs,
+            tap,
+            api_socket,
+            vsock_socket: vsock_socket.clone(),
+            serial_log,
+        };
+        (ip, vsock_socket, cfg)
+        // conn dropped here — no borrow across await
     };
 
-    db::insert_vm(conn, &vm).context("insert VM into DB")?;
+    // ── Async: spawn CH, wait for agent, configure network ───────────────────
+    let result = async {
+        let pid = hypervisor::spawn(&cfg).context("spawn cloud-hypervisor")?;
+        info!("cloud-hypervisor PID={pid}");
 
-    // Spawn cloud-hypervisor.
-    let cfg = hypervisor::VmConfig {
-        name: name.to_string(),
-        vcpus,
-        memory_mb,
-        mac,
-        cid,
-        rootfs: rootfs.clone(),
-        tap,
-        api_socket: api_socket.clone(),
-        vsock_socket: vsock_socket.clone(),
-        serial_log,
-    };
+        {
+            let conn = db::open(db_path)?;
+            db::update_vm_status(&conn, name, "starting", Some(pid as i64))?;
+        }
 
-    let pid = hypervisor::spawn(&cfg).context("spawn cloud-hypervisor")?;
-    info!("cloud-hypervisor PID={pid}");
+        info!("waiting for agent to become ready…");
+        agent::wait_ready(&vsock_socket, Duration::from_secs(60))
+            .await
+            .context("wait for agent ready")?;
 
-    db::update_vm_status(conn, name, "starting", Some(pid as i64))
-        .context("update VM status to starting")?;
-
-    // Wait for agent to be ready (up to 60 seconds).
-    info!("waiting for agent to become ready…");
-    agent::wait_ready(&vsock_socket, Duration::from_secs(60))
-        .await
-        .context("wait for agent ready")?;
-
-    info!("agent ready, configuring network");
-
-    // Configure guest networking.
-    agent::configure_network(
-        &vsock_socket,
-        &format!("{ip}/16"),
-        "10.0.0.1",
-        vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()],
-    )
-    .await
-    .context("configure guest network")?;
-
-    // Inject SSH public key if provided.
-    if let Some(pubkey) = ssh_pubkey {
-        info!("injecting SSH public key into VM");
-        let script = format!(
-            "mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
-             echo '{pubkey}' >> /root/.ssh/authorized_keys && \
-             chmod 600 /root/.ssh/authorized_keys"
-        );
-        agent::send_request(
+        info!("agent ready, configuring network");
+        agent::configure_network(
             &vsock_socket,
-            Request::Exec {
-                command: "sh".to_string(),
-                args: vec!["-c".to_string(), script],
-            },
+            &format!("{ip}/16"),
+            "10.0.0.1",
+            vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()],
         )
         .await
-        .context("inject SSH key")?;
+        .context("configure guest network")?;
+
+        if let Some(pubkey) = ssh_pubkey {
+            info!("injecting SSH public key into VM");
+            let script = format!(
+                "mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
+                 echo '{pubkey}' >> /root/.ssh/authorized_keys && \
+                 chmod 600 /root/.ssh/authorized_keys"
+            );
+            agent::send_request(
+                &vsock_socket,
+                Request::Exec {
+                    command: "sh".to_string(),
+                    args: vec!["-c".to_string(), script],
+                },
+            )
+            .await
+            .context("inject SSH key")?;
+        }
+
+        anyhow::Ok(())
+    }
+    .await;
+
+    // ── Rollback on failure ───────────────────────────────────────────────────
+    if let Err(e) = result {
+        info!("create failed ({e:#}), rolling back…");
+        let pid = {
+            let conn = db::open(db_path).ok();
+            conn.and_then(|c| db::get_vm(&c, name).ok().flatten()).and_then(|v| v.ch_pid)
+        };
+        let _ = hypervisor::shutdown(name, pid);
+        let _ = network::destroy_tap(name);
+        let _ = storage::destroy_rootfs(name);
+        if let Ok(conn) = db::open(db_path) {
+            let _ = db::delete_vm(&conn, name);
+        }
+        return Err(e);
     }
 
-    db::update_vm_status(conn, name, "running", None).context("update VM status to running")?;
-
-    let vm = db::get_vm(conn, name)?.expect("VM just inserted");
-    Ok(vm)
+    // ── Sync: mark running, return record ────────────────────────────────────
+    let conn = db::open(db_path)?;
+    db::update_vm_status(&conn, name, "running", None)
+        .context("update VM status to running")?;
+    db::get_vm(&conn, name)?.context("VM vanished after create")
 }
 
 /// Destroy a VM: shutdown CH, delete TAP, delete rootfs, remove DB row.
-pub async fn destroy(conn: &Connection, name: &str) -> Result<()> {
-    let vm = db::get_vm(conn, name)?
-        .with_context(|| format!("VM '{name}' not found"))?;
+pub async fn destroy(db_path: &str, name: &str) -> Result<()> {
+    // ── Sync: look up VM ─────────────────────────────────────────────────────
+    let ch_pid = {
+        let conn = db::open(db_path)?;
+        let vm = db::get_vm(&conn, name)?
+            .with_context(|| format!("VM '{name}' not found"))?;
+        db::update_vm_status(&conn, name, "stopping", None)?;
+        vm.ch_pid
+        // conn dropped here
+    };
 
-    db::update_vm_status(conn, name, "stopping", None)?;
-
-    // Graceful CH shutdown.
-    hypervisor::shutdown(name, vm.ch_pid).context("shutdown hypervisor")?;
-
-    // Tear down networking.
+    // ── Sync (blocking but not holding connection): shutdown CH ──────────────
+    hypervisor::shutdown(name, ch_pid).context("shutdown hypervisor")?;
     network::destroy_tap(name).context("destroy TAP")?;
-
-    // Remove rootfs.
     storage::destroy_rootfs(name).context("destroy rootfs")?;
 
-    // Remove DB record.
-    db::delete_vm(conn, name)?;
-
+    // ── Sync: remove DB record ───────────────────────────────────────────────
+    let conn = db::open(db_path)?;
+    db::delete_vm(&conn, name)?;
     Ok(())
 }
 
 /// List all VMs, correcting stale "running" status for dead processes.
-pub fn list(conn: &Connection) -> Result<Vec<db::Vm>> {
+pub fn list(conn: &rusqlite::Connection) -> Result<Vec<db::Vm>> {
     let mut vms = db::list_vms(conn)?;
-
     for vm in &mut vms {
         if vm.status == "running" && !hypervisor::is_alive_pid(vm.ch_pid) {
             vm.status = "error (process dead)".to_string();
             let _ = db::update_vm_status(conn, &vm.name, "error", None);
         }
     }
-
     Ok(vms)
 }
 
@@ -166,10 +186,7 @@ fn validate_name(name: &str) -> Result<()> {
     if name.len() > 11 {
         anyhow::bail!("VM name must be 11 characters or fewer (TAP device limit)");
     }
-    if !name
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-')
-    {
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
         anyhow::bail!("VM name must only contain alphanumeric characters and hyphens");
     }
     Ok(())

--- a/docs/phase-4-setup.md
+++ b/docs/phase-4-setup.md
@@ -1,0 +1,192 @@
+# Phase 4 — HTTP API + Daemon Mode
+
+Phase 4 turns `minions` from a local-only CLI into a daemon with an HTTP REST API,
+accessible remotely over Tailscale from any device.
+
+**Tested on:** minipc — AMD Ryzen 5 4500U, Ubuntu 24.04.4 LTS
+
+---
+
+## What's New
+
+| Feature | Description |
+|---|---|
+| `minions init` | One-command host setup (br0, iptables, dirs, systemd unit) |
+| `minions serve` | HTTP API daemon on port 3000 |
+| Startup reconciliation | Detects crashed VMs, cleans orphans on daemon start |
+| Create rollback | Partial-create failures clean up TAP + rootfs + DB automatically |
+| Remote CLI | `minions --host http://minipc:3000 list` from your Mac |
+| HTTP API | Full REST API for VMs — create, destroy, list, exec, status, logs |
+
+---
+
+## Deployment
+
+### 1. Pull and bake
+
+```bash
+cd /tmp/minions && git pull origin main
+sudo bash ./scripts/bake-agent.sh
+```
+
+### 2. One-time host setup
+
+```bash
+# Sets up br0, ip_forward, iptables, directories, systemd unit
+sudo minions init
+
+# Optional: persist networking across reboots
+sudo minions init --persist
+```
+
+### 3. Start the daemon
+
+```bash
+sudo systemctl enable --now minions
+sudo systemctl status minions
+```
+
+### 4. Verify
+
+```bash
+# Local
+sudo minions list
+
+# Remote (from Mac over Tailscale)
+curl http://minipc:3000/api/vms
+```
+
+---
+
+## HTTP API Reference
+
+Base URL: `http://minipc:3000`
+
+### Create a VM
+
+```bash
+curl -X POST http://minipc:3000/api/vms \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"myvm","cpus":2,"memory_mb":1024}'
+```
+
+```json
+{
+  "name": "myvm",
+  "status": "running",
+  "ip": "10.0.0.2",
+  "vsock_cid": 3,
+  "cpus": 2,
+  "memory_mb": 1024,
+  "pid": 12345,
+  "created_at": "2026-02-18T10:00:00Z"
+}
+```
+
+### List VMs
+
+```bash
+curl http://minipc:3000/api/vms
+```
+
+### Get VM details
+
+```bash
+curl http://minipc:3000/api/vms/myvm
+```
+
+### Execute a command
+
+```bash
+curl -X POST http://minipc:3000/api/vms/myvm/exec \
+  -H 'Content-Type: application/json' \
+  -d '{"command":"uname","args":["-a"]}'
+```
+
+```json
+{"exit_code":0,"stdout":"Linux cloud-hypervisor 6.16.9+...\n","stderr":""}
+```
+
+### Agent status
+
+```bash
+curl http://minipc:3000/api/vms/myvm/status
+```
+
+### Serial console log
+
+```bash
+curl http://minipc:3000/api/vms/myvm/logs
+```
+
+### Destroy a VM
+
+```bash
+curl -X DELETE http://minipc:3000/api/vms/myvm
+```
+
+---
+
+## Remote CLI
+
+When `--host` is set, the CLI is a thin HTTP client — no sudo, no SSH into minipc:
+
+```bash
+# From Mac
+minions --host http://minipc:3000 list
+minions --host http://minipc:3000 create myvm --cpus 4
+minions --host http://minipc:3000 exec myvm -- uname -a
+minions --host http://minipc:3000 destroy myvm
+```
+
+Auto-detect: if `--host` is omitted and a local daemon is running on
+`127.0.0.1:3000`, the CLI uses it automatically (no sudo needed).
+
+---
+
+## Daemon Behaviour
+
+### Startup Reconciliation
+
+When `minions serve` starts, it:
+1. Queries all VMs with non-stopped status from the DB
+2. For each VM, checks if the `cloud-hypervisor` process (PID) is alive
+3. Dead VMs → cleans TAP device + socket files → marks DB status `stopped`
+4. Removes orphan socket files in `/run/minions/` with no DB entry
+
+This handles: host reboots, OOM kills, crashed CH processes, partial creates.
+
+### Create Rollback
+
+If VM creation fails at any step (TAP create, CH spawn, agent timeout, network
+config), all created resources are cleaned up automatically:
+- CH process killed
+- TAP device removed
+- Rootfs directory deleted
+- DB row removed
+
+---
+
+## Architecture
+
+```
+crates/minions/src/
+├── main.rs       # CLI entry point — routes to remote/direct/daemon mode
+├── api.rs        # axum HTTP routes
+├── server.rs     # Daemon: startup reconciliation + HTTP server
+├── client.rs     # reqwest HTTP client (CLI remote mode)
+├── init.rs       # Host setup: bridge, iptables, dirs, systemd unit
+├── vm.rs         # VM lifecycle (connection never held across .await)
+├── hypervisor.rs # CH process management
+├── network.rs    # TAP + bridge management
+├── storage.rs    # Rootfs management
+├── agent.rs      # VSOCK client
+└── db.rs         # SQLite state
+```
+
+### Key Design Decision: No Connection Held Across `.await`
+
+`rusqlite::Connection` is `Send` but not `Sync`, so `&Connection` cannot be
+held across `.await` points in async handlers. All async VM functions (`create`,
+`destroy`) open short-lived connections for each sync DB operation, dropping
+them before any `await`.


### PR DESCRIPTION
Closes #4

## What's in this PR

### New features

| | |
|---|---|
| `minions init` | One-command host setup: br0, iptables, dirs, systemd unit — idempotent, `--persist` flag for reboot survival |
| `minions serve` | HTTP API daemon (axum, port 3000), starts with startup reconciliation |
| Startup reconciliation | Detects crashed VMs, cleans orphan TAPs/sockets, fixes stale DB on daemon start |
| Create rollback | Any failure mid-create (CH spawn, agent timeout, etc.) cleans up all resources automatically |
| `--host` flag | CLI becomes a thin HTTP client: `minions --host http://minipc:3000 list` |
| Auto-detect daemon | If local daemon is running on 127.0.0.1:3000, CLI uses it automatically (no sudo) |

### HTTP API

```
POST   /api/vms              → create VM (201)
GET    /api/vms              → list all VMs
GET    /api/vms/:name        → VM details
DELETE /api/vms/:name        → destroy VM
POST   /api/vms/:name/exec  → run command in VM
GET    /api/vms/:name/status → agent status
GET    /api/vms/:name/logs   → serial console log
```

### New files

| File | Purpose |
|---|---|
| `src/api.rs` | axum HTTP routes |
| `src/server.rs` | Daemon: reconcile on start + axum serve |
| `src/client.rs` | reqwest HTTP client for `--host` mode |
| `src/init.rs` | Host setup automation |
| `docs/phase-4-setup.md` | Setup + API reference |

### Key change: `vm.rs` refactored for async safety

`rusqlite::Connection` is `!Sync`, so `&Connection` cannot be held across `.await` points (axum's `Handler` bound requires `Send` futures). `vm::create` and `vm::destroy` now take `db_path: &str` and open short-lived connections around each sync DB operation, dropping them before any `.await`.