### PR TITLE
feat: Phase 5 — restart, rename, cp, --json output (#8)

### DIFF
--- a/crates/minions/src/agent.rs
+++ b/crates/minions/src/agent.rs
@@ -52,9 +52,8 @@ pub async fn wait_ready(vsock_socket: &Path, timeout: Duration) -> Result<()> {
     let mut backoff = Duration::from_millis(100);
 
     loop {
-        match send_request(vsock_socket, Request::HealthCheck).await {
-            Ok(_) => return Ok(()),
-            Err(_) => {}
+        if send_request(vsock_socket, Request::HealthCheck).await.is_ok() {
+            return Ok(());
         }
 
         if tokio::time::Instant::now() >= deadline {

--- a/crates/minions/src/client.rs
+++ b/crates/minions/src/client.rs
@@ -90,6 +90,45 @@ impl Client {
         Ok(())
     }
 
+    pub async fn restart_vm(&self, name: &str) -> Result<VmResponse> {
+        self.http
+            .post(format!("{}/api/vms/{name}/restart", self.base))
+            .send()
+            .await
+            .context("send restart request")?
+            .error_for_status()
+            .context("restart VM")?
+            .json()
+            .await
+            .context("decode restart response")
+    }
+
+    pub async fn rename_vm(&self, name: &str, new_name: &str) -> Result<()> {
+        self.http
+            .post(format!("{}/api/vms/{name}/rename", self.base))
+            .json(&serde_json::json!({ "new_name": new_name }))
+            .send()
+            .await
+            .context("send rename request")?
+            .error_for_status()
+            .context("rename VM")?;
+        Ok(())
+    }
+
+    pub async fn copy_vm(&self, name: &str, new_name: &str) -> Result<VmResponse> {
+        self.http
+            .post(format!("{}/api/vms/{name}/copy", self.base))
+            .json(&serde_json::json!({ "new_name": new_name }))
+            .send()
+            .await
+            .context("send copy request")?
+            .error_for_status()
+            .context("copy VM")?
+            .json()
+            .await
+            .context("decode copy response")
+    }
+
     pub async fn exec_vm(&self, name: &str, req: ExecRequest) -> Result<ExecResponse> {
         self.http
             .post(format!("{}/api/vms/{name}/exec", self.base))

--- a/crates/minions/src/hypervisor.rs
+++ b/crates/minions/src/hypervisor.rs
@@ -82,6 +82,21 @@ pub fn spawn(cfg: &VmConfig) -> Result<u32> {
     Ok(child.id())
 }
 
+/// Reboot a VM via the CH API (`vm.reboot`).
+///
+/// Cloud Hypervisor sends an ACPI reset signal to the guest; the guest OS
+/// performs a clean reboot without the VMM process restarting.
+/// Returns `Ok(())` on success, error if the CH API call fails.
+pub fn reboot(name: &str) -> Result<()> {
+    let api_socket = api_socket_path(name);
+    if !api_socket.exists() {
+        anyhow::bail!("API socket not found for VM '{name}' — is it running?");
+    }
+    curl_put(&api_socket.to_string_lossy(), "vm.reboot")
+        .with_context(|| format!("reboot VM '{name}'"))?;
+    Ok(())
+}
+
 /// Gracefully shut down a VM via the CH API, falling back to SIGKILL.
 pub fn shutdown(name: &str, pid: Option<i64>) -> Result<()> {
     let api_socket = api_socket_path(name);

--- a/crates/minions/src/network.rs
+++ b/crates/minions/src/network.rs
@@ -50,6 +50,12 @@ pub fn generate_mac(cid: u32) -> String {
     format!("52:54:00:00:{high:02x}:{low:02x}")
 }
 
+/// Public alias so callers (e.g. `vm::rename`) can compute the TAP name
+/// without duplicating the truncation logic.
+pub fn tap_name_for(name: &str) -> String {
+    tap_name(name)
+}
+
 /// TAP device name derived from VM name (max 15 chars total).
 fn tap_name(name: &str) -> String {
     let prefix = "tap-";

--- a/crates/minions/src/vm.rs
+++ b/crates/minions/src/vm.rs
@@ -176,6 +176,241 @@ pub async fn destroy(db_path: &str, name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Restart a running VM via the Cloud Hypervisor ACPI reset signal.
+///
+/// If the CH API call succeeds the VMM process stays alive and the guest
+/// OS performs a clean reboot.  The agent will briefly become unreachable
+/// during the reboot cycle; callers should not immediately issue agent
+/// requests after this returns.
+pub async fn restart(db_path: &str, name: &str) -> Result<db::Vm> {
+    // Verify the VM exists and is running.
+    {
+        let conn = db::open(db_path)?;
+        let vm = db::get_vm(&conn, name)?
+            .with_context(|| format!("VM '{name}' not found"))?;
+        if vm.status != "running" {
+            anyhow::bail!("VM '{name}' is not running (status: {})", vm.status);
+        }
+        db::update_vm_status(&conn, name, "restarting", None)?;
+    } // conn dropped
+
+    // Send reboot signal.  If it fails we restore the running status and bail.
+    if let Err(e) = hypervisor::reboot(name) {
+        let conn = db::open(db_path)?;
+        let _ = db::update_vm_status(&conn, name, "running", None);
+        return Err(e);
+    }
+
+    // Mark running again — the VM stays alive, we just signalled a guest reboot.
+    let conn = db::open(db_path)?;
+    db::update_vm_status(&conn, name, "running", None)?;
+    db::get_vm(&conn, name)?.with_context(|| format!("VM '{name}' vanished after restart"))
+}
+
+/// Rename a stopped VM.
+///
+/// The VM **must** be stopped; renaming a running VM would leave socket paths
+/// and TAP device names out of sync with the new name.
+pub async fn rename(db_path: &str, old_name: &str, new_name: &str) -> Result<()> {
+    validate_name(new_name)?;
+
+    let (old_rootfs, old_tap) = {
+        let conn = db::open(db_path)?;
+
+        // Source must exist.
+        let vm = db::get_vm(&conn, old_name)?
+            .with_context(|| format!("VM '{old_name}' not found"))?;
+
+        if vm.status != "stopped" {
+            anyhow::bail!(
+                "VM '{old_name}' must be stopped before renaming (status: {})",
+                vm.status
+            );
+        }
+
+        // Destination name must not exist.
+        if db::get_vm(&conn, new_name)?.is_some() {
+            anyhow::bail!("VM '{new_name}' already exists");
+        }
+
+        (vm.rootfs_path, vm.tap_device)
+    };
+
+    // Rename filesystem directory (rootfs lives at VMS_DIR/{name}/).
+    let old_vm_dir = std::path::PathBuf::from(storage::VMS_DIR).join(old_name);
+    let new_vm_dir = std::path::PathBuf::from(storage::VMS_DIR).join(new_name);
+    if old_vm_dir.exists() {
+        std::fs::rename(&old_vm_dir, &new_vm_dir)
+            .with_context(|| format!("rename VM dir {:?} → {:?}", old_vm_dir, new_vm_dir))?;
+    }
+
+    // Rename TAP device (best-effort; may not exist if VM was already cleaned up).
+    let new_tap = network::tap_name_for(new_name);
+    let _ = std::process::Command::new("ip")
+        .args(["link", "set", &old_tap, "name", &new_tap])
+        .status();
+
+    // Derive new path strings.
+    let new_rootfs = old_rootfs.replace(old_name, new_name);
+    let new_api_socket = hypervisor::api_socket_path(new_name);
+    let new_vsock_socket = hypervisor::vsock_socket_path(new_name);
+
+    let conn = db::open(db_path)?;
+    db::rename_vm(
+        &conn,
+        old_name,
+        new_name,
+        &new_tap,
+        &new_api_socket.to_string_lossy(),
+        &new_vsock_socket.to_string_lossy(),
+        &new_rootfs,
+    )?;
+
+    Ok(())
+}
+
+/// Copy an existing VM to a new VM.
+///
+/// Creates an independent copy of the source VM's rootfs, allocates fresh
+/// network resources (IP, CID, TAP), and boots it.  The source VM may be
+/// running or stopped.
+pub async fn copy(
+    db_path: &str,
+    source_name: &str,
+    new_name: &str,
+    ssh_pubkey: Option<String>,
+) -> Result<db::Vm> {
+    validate_name(new_name)?;
+
+    let (ip, vsock_socket, cfg) = {
+        let conn = db::open(db_path)?;
+
+        // Source must exist.
+        let source = db::get_vm(&conn, source_name)?
+            .with_context(|| format!("VM '{source_name}' not found"))?;
+
+        // Destination must not exist.
+        if db::get_vm(&conn, new_name)?.is_some() {
+            anyhow::bail!("VM '{new_name}' already exists");
+        }
+
+        network::check_bridge().context("bridge check")?;
+        hypervisor::ensure_run_dir()?;
+
+        let ip = db::next_available_ip(&conn)?;
+        let cid = db::next_available_cid(&conn)?;
+        let mac = network::generate_mac(cid);
+        let tap = network::create_tap(new_name).context("create TAP device")?;
+        let rootfs = storage::copy_rootfs(source_name, new_name)
+            .context("copy source rootfs")?;
+
+        let api_socket = hypervisor::api_socket_path(new_name);
+        let vsock_socket = hypervisor::vsock_socket_path(new_name);
+        let serial_log = storage::serial_log_path(new_name);
+
+        let vm_row = db::Vm {
+            name: new_name.to_string(),
+            status: "creating".to_string(),
+            ip: ip.clone(),
+            vsock_cid: cid,
+            ch_pid: None,
+            ch_api_socket: api_socket.to_string_lossy().to_string(),
+            ch_vsock_socket: vsock_socket.to_string_lossy().to_string(),
+            tap_device: tap.clone(),
+            mac_address: mac.clone(),
+            vcpus: source.vcpus,
+            memory_mb: source.memory_mb,
+            rootfs_path: rootfs.to_string_lossy().to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            stopped_at: None,
+        };
+        db::insert_vm(&conn, &vm_row).context("insert copied VM into DB")?;
+
+        let cfg = hypervisor::VmConfig {
+            name: new_name.to_string(),
+            vcpus: source.vcpus,
+            memory_mb: source.memory_mb,
+            mac,
+            cid,
+            rootfs,
+            tap,
+            api_socket,
+            vsock_socket: vsock_socket.clone(),
+            serial_log,
+        };
+        (ip, vsock_socket, cfg)
+        // conn dropped
+    };
+
+    // Same async boot sequence as create().
+    let result = async {
+        let pid = hypervisor::spawn(&cfg).context("spawn cloud-hypervisor")?;
+        info!("cloud-hypervisor PID={pid}");
+
+        {
+            let conn = db::open(db_path)?;
+            db::update_vm_status(&conn, new_name, "starting", Some(pid as i64))?;
+        }
+
+        info!("waiting for agent to become ready…");
+        agent::wait_ready(&vsock_socket, std::time::Duration::from_secs(60))
+            .await
+            .context("wait for agent ready")?;
+
+        info!("configuring network for copied VM");
+        agent::configure_network(
+            &vsock_socket,
+            &format!("{ip}/16"),
+            "10.0.0.1",
+            vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()],
+        )
+        .await
+        .context("configure guest network")?;
+
+        if let Some(pubkey) = ssh_pubkey {
+            let pubkey = pubkey.trim();
+            if !pubkey.starts_with("ssh-") && !pubkey.starts_with("ecdsa-") {
+                anyhow::bail!("invalid SSH public key format");
+            }
+            agent::send_request(
+                &vsock_socket,
+                Request::WriteFile {
+                    path: "/root/.ssh/authorized_keys".to_string(),
+                    content: format!("{}\n", pubkey),
+                    mode: 0o600,
+                    append: false, // overwrite — key came from current host user
+                },
+            )
+            .await
+            .context("inject SSH key into copied VM")?;
+        }
+
+        anyhow::Ok(())
+    }
+    .await;
+
+    // Rollback on failure.
+    if let Err(e) = result {
+        info!("copy failed ({e:#}), rolling back…");
+        let pid = {
+            let conn = db::open(db_path).ok();
+            conn.and_then(|c| db::get_vm(&c, new_name).ok().flatten())
+                .and_then(|v| v.ch_pid)
+        };
+        let _ = hypervisor::shutdown(new_name, pid);
+        let _ = network::destroy_tap(new_name);
+        let _ = storage::destroy_rootfs(new_name);
+        if let Ok(conn) = db::open(db_path) {
+            let _ = db::delete_vm(&conn, new_name);
+        }
+        return Err(e);
+    }
+
+    let conn = db::open(db_path)?;
+    db::update_vm_status(&conn, new_name, "running", None)?;
+    db::get_vm(&conn, new_name)?.with_context(|| format!("VM '{new_name}' vanished after copy"))
+}
+
 /// List all VMs, correcting stale "running" status for dead processes.
 pub fn list(conn: &rusqlite::Connection) -> Result<Vec<db::Vm>> {
     let mut vms = db::list_vms(conn)?;

--- a/docs/phase-5-setup.md
+++ b/docs/phase-5-setup.md
@@ -1,0 +1,229 @@
+# Phase 5 — VM Lifecycle Completions
+
+Phase 5 rounds out the basic VM lifecycle with `restart`, `rename`, `cp`, and a
+`--json` output flag.  No new runtime dependencies or infra changes are required
+— all additions live inside the existing `minions` binary.
+
+---
+
+## What's New
+
+| Feature | Command | API endpoint |
+|---------|---------|--------------|
+| VM restart | `minions restart <name>` | `POST /api/vms/{name}/restart` |
+| VM rename  | `minions rename <old> <new>` | `POST /api/vms/{name}/rename` |
+| VM copy    | `minions cp <source> [new-name]` | `POST /api/vms/{name}/copy` |
+| JSON output | `--json` (global flag) | all endpoints already return JSON |
+
+---
+
+## Upgrade
+
+Pull and rebuild:
+
+```bash
+cd /tmp/minions && git pull origin main
+sudo bash ./scripts/bake-agent.sh   # rebuilds + installs /usr/local/bin/minions
+sudo systemctl restart minions       # reload daemon
+```
+
+---
+
+## Usage
+
+### VM Restart
+
+Sends an ACPI reboot signal to the guest via Cloud Hypervisor.  The VMM
+process stays alive; the guest OS performs a clean reboot.  The VM will be
+briefly unreachable over SSH / VSOCK while the guest boots.
+
+```bash
+# Direct (local)
+sudo minions restart myvm
+
+# Remote
+minions --host http://minipc:3000 restart myvm
+
+# JSON output
+sudo minions --json restart myvm
+```
+
+```json
+{
+  "name": "myvm",
+  "status": "running",
+  "ip": "10.0.0.2",
+  "cpus": 2,
+  "memory_mb": 1024,
+  "pid": 12345
+}
+```
+
+**Rules:**
+- VM must be in `running` state.  Returns an error for stopped/creating VMs.
+- If the CH API call fails (e.g. VMM crashed), the status is restored to `running`
+  and the error is returned to the caller.
+
+### VM Rename
+
+Renames a stopped VM.  The filesystem directory, TAP device, and all DB columns
+are updated atomically.
+
+```bash
+# VM must be stopped first
+sudo minions destroy myvm   # or wait for it to stop
+
+# Then rename
+sudo minions rename myvm production-api
+
+# Or via API
+curl -X POST http://minipc:3000/api/vms/myvm/rename \
+  -H 'Content-Type: application/json' \
+  -d '{"new_name": "production-api"}'
+```
+
+**Rules:**
+- Source VM must exist.
+- Source VM must be in `stopped` state.  Renaming a running VM would leave
+  socket paths and TAP device names out of sync.
+- Destination name must not already exist.
+- Name validation applies (≤ 11 chars, alphanumeric + hyphens).
+
+### VM Copy
+
+Creates an independent VM from a copy of an existing VM's rootfs.  The source
+may be running or stopped.  The copy gets a fresh IP, VSOCK CID, TAP device,
+and boots normally.
+
+```bash
+# Copy with auto-generated name (source + "-copy" suffix)
+sudo minions cp myvm
+
+# Copy with explicit name
+sudo minions cp myvm myvm-staging
+
+# Remote
+minions --host http://minipc:3000 cp myvm myvm-staging
+
+# JSON output
+sudo minions --json cp myvm
+```
+
+```json
+{
+  "name": "myvm-copy",
+  "status": "running",
+  "ip": "10.0.0.3",
+  "cpus": 2,
+  "memory_mb": 1024,
+  "pid": 12399
+}
+```
+
+**Rules:**
+- Source VM must exist (but may be running or stopped).
+- The copy inherits the source's CPU and memory config.
+- Rootfs is copied with `cp --sparse=always` — fast and space-efficient.
+- The copy gets a fresh SSH authorized_keys from the host user's key (same as `create`).
+- If boot fails, all resources (TAP, rootfs copy, DB row) are cleaned up.
+
+**Auto-generated name:** if no name is supplied, the copy is named
+`{source_prefix}-copy` where `source_prefix` is the first 6 chars of the
+source name (to stay within the 11-char TAP limit).
+
+### JSON Output (`--json`)
+
+Add `--json` anywhere in the command line to receive machine-readable output.
+
+```bash
+# List as JSON array
+sudo minions --json list
+
+# Single VM as JSON object
+sudo minions --json create myvm
+sudo minions --json restart myvm
+
+# Destructive operations return a message object
+sudo minions --json destroy myvm
+sudo minions --json rename myvm newname
+```
+
+**`list` output:**
+```json
+[
+  {
+    "name": "myvm",
+    "status": "running",
+    "ip": "10.0.0.2",
+    "cpus": 2,
+    "memory_mb": 1024,
+    "pid": 12345
+  }
+]
+```
+
+**Destructive operation output:**
+```json
+{ "message": "VM 'myvm' destroyed" }
+```
+
+---
+
+## API Reference
+
+All new endpoints require the same bearer-token auth as existing ones.
+
+### `POST /api/vms/{name}/restart`
+
+No request body required.
+
+**Response:** `200 OK` — VM object  
+**Errors:** `404` not found, `500` CH API failure
+
+### `POST /api/vms/{name}/rename`
+
+```json
+{ "new_name": "production-api" }
+```
+
+**Response:** `200 OK`
+```json
+{ "message": "VM 'myvm' renamed to 'production-api'" }
+```
+**Errors:** `404` not found, `400` not stopped / name conflict / invalid name
+
+### `POST /api/vms/{name}/copy`
+
+```json
+{ "new_name": "myvm-staging" }
+```
+
+**Response:** `201 Created` — new VM object  
+**Errors:** `404` source not found, `400` destination already exists / invalid name
+
+---
+
+## Architecture Notes
+
+### `hypervisor::reboot()`
+
+Uses the CH REST API endpoint `PUT /api/v1/vm.reboot`.  Cloud Hypervisor sends
+an ACPI reset to the guest; the VMM process does **not** restart.  This is the
+fastest possible reboot path — no process respawn, no rootfs re-copy, no VSOCK
+re-handshake required (VSOCK CID stays the same).
+
+### `vm::rename()`
+
+Steps:
+1. Validate new name (≤ 11 chars, alphanumeric + hyphens)
+2. Check source exists + is stopped
+3. Check destination doesn't exist
+4. `mv` the rootfs directory (`VMS_DIR/{old}` → `VMS_DIR/{new}`)
+5. `ip link set tap-{old} name tap-{new}` (best-effort)
+6. Update DB: name, tap_device, ch_api_socket, ch_vsock_socket, rootfs_path
+
+### `vm::copy()`
+
+Identical to `vm::create()` except step 3 uses `cp --sparse=always` from the
+source VM's rootfs instead of the base image.  The agent is re-contacted to
+configure a new IP; SSH keys are re-injected from the host user's public key.


### PR DESCRIPTION
Implements Phase 5 from issue #8 — VM lifecycle completions.

## Changes

### New commands / endpoints

| Command | API | Description |
|---------|-----|-------------|
| `minions restart <name>` | `POST /api/vms/{name}/restart` | ACPI reboot via CH `vm.reboot` — VMM stays alive |
| `minions rename <old> <new>` | `POST /api/vms/{name}/rename` | Rename a stopped VM (rootfs dir + TAP + all DB paths) |
| `minions cp <source> [new-name]` | `POST /api/vms/{name}/copy` | Copy rootfs, allocate fresh network resources, boot |
| `--json` (global flag) | n/a | Machine-readable output on all commands |

### File changes

| File | Change |
|------|--------|
| `hypervisor.rs` | Add `reboot()` — `PUT /api/v1/vm.reboot` via CH API |
| `storage.rs` | Add `copy_rootfs()` — `cp --sparse=always` from existing VM dir |
| `db.rs` | Add `rename_vm()` — atomic update of all name-derived columns |
| `network.rs` | Add `tap_name_for()` — public alias used by `vm::rename` |
| `vm.rs` | Add `restart()`, `rename()`, `copy()` orchestration functions |
| `api.rs` | Add `/restart`, `/rename`, `/copy` routes + request types + handlers |
| `client.rs` | Add `restart_vm()`, `rename_vm()`, `copy_vm()` HTTP client methods |
| `main.rs` | Add `Restart`, `Rename`, `Cp` CLI commands; add global `--json` flag; unified `VmJson` + `print_vm` / `print_vm_list` helpers |
| `agent.rs` | Fix pre-existing clippy warning (`match` → `if let`) |
| `docs/phase-5-setup.md` | Full documentation for Phase 5 |

## Behaviour notes

- **restart**: VM must be `running`. Sends ACPI reset — no VMM respawn. Fast.
- **rename**: VM must be `stopped`. Moves rootfs dir, renames TAP (best-effort), updates DB atomically.
- **cp**: Source may be running or stopped. Inherits source CPU/RAM. Full rollback on failure (same pattern as `create`). Auto-name is `{src_prefix}-copy`.
- **--json**: `list` → JSON array; create/restart/cp → VM object; destroy/rename → `{"message":"..."}`.

Closes part of #8 (Phase 5 complete).