### PR TITLE
fix: add stop, fix destroy/rename to use stored DB paths

### DIFF
--- a/crates/minions/src/client.rs
+++ b/crates/minions/src/client.rs
@@ -90,6 +90,19 @@ impl Client {
         Ok(())
     }
 
+    pub async fn stop_vm(&self, name: &str) -> Result<VmResponse> {
+        self.http
+            .post(format!("{}/api/vms/{name}/stop", self.base))
+            .send()
+            .await
+            .context("send stop request")?
+            .error_for_status()
+            .context("stop VM")?
+            .json()
+            .await
+            .context("decode stop response")
+    }
+
     pub async fn restart_vm(&self, name: &str) -> Result<VmResponse> {
         self.http
             .post(format!("{}/api/vms/{name}/restart", self.base))

--- a/crates/minions/src/db.rs
+++ b/crates/minions/src/db.rs
@@ -173,6 +173,21 @@ pub fn rename_vm(
     Ok(())
 }
 
+/// Rename a running VM: only update the `name` column.
+/// All stored paths (sockets, TAP, rootfs) remain unchanged.
+pub fn rename_vm_name_only(conn: &Connection, old_name: &str, new_name: &str) -> Result<()> {
+    let updated = conn
+        .execute(
+            "UPDATE vms SET name = ?1 WHERE name = ?2",
+            rusqlite::params![new_name, old_name],
+        )
+        .context("rename vm name in db")?;
+    if updated == 0 {
+        anyhow::bail!("VM '{}' not found", old_name);
+    }
+    Ok(())
+}
+
 /// Delete a VM record.
 pub fn delete_vm(conn: &Connection, name: &str) -> Result<()> {
     conn.execute("DELETE FROM vms WHERE name=?1", params![name])

--- a/crates/minions/src/network.rs
+++ b/crates/minions/src/network.rs
@@ -19,11 +19,16 @@ pub fn create_tap(name: &str) -> Result<String> {
     Ok(tap)
 }
 
-/// Delete a TAP device.
+/// Delete a TAP device by VM name (derives the tap device name).
 pub fn destroy_tap(name: &str) -> Result<()> {
-    let tap = tap_name(name);
+    destroy_tap_device(&tap_name(name))
+}
+
+/// Delete a TAP device by its exact device name.
+/// Use this when you have the stored tap name from the DB (e.g. after rename).
+pub fn destroy_tap_device(tap: &str) -> Result<()> {
     // Best-effort: ignore errors if device doesn't exist.
-    let _ = run("ip", &["link", "del", &tap]);
+    let _ = run("ip", &["link", "del", tap]);
     Ok(())
 }
 

--- a/crates/minions/src/server.rs
+++ b/crates/minions/src/server.rs
@@ -35,8 +35,8 @@ pub fn reconcile(db_path: &str) -> Result<()> {
                         status = %vm.status,
                         "CH process dead — marking stopped and cleaning up"
                     );
-                    // Best-effort cleanup.
-                    let _ = network::destroy_tap(&vm.name);
+                    // Best-effort cleanup — use stored paths, not derived from name.
+                    let _ = network::destroy_tap_device(&vm.tap_device);
                     for sock in [&vm.ch_api_socket, &vm.ch_vsock_socket] {
                         let _ = std::fs::remove_file(sock);
                     }


### PR DESCRIPTION
Found during testing on minipc.

## Issues fixed

1. **`rename` required `stopped` state, but there was no `stop` command** — impossible to reach the required state without destroying the VM entirely.

2. **`destroy` and reconcile derived socket/TAP paths from the VM name** — after a rename, destroy would look for `tap-{newname}` and `/run/minions/{newname}.sock` which do not exist (the actual resources still have the original name).

## Changes

- `hypervisor::shutdown_vm(api_socket, vsock_socket, pid)` — takes stored paths instead of name; `shutdown(name, pid)` is kept as a convenience wrapper for create-rollback paths
- `network::destroy_tap_device(tap)` — takes actual tap device name; `destroy_tap(name)` delegates to it
- `vm::stop()` — new operation: halt CH process + remove TAP, keep rootfs + DB record → status `stopped`
- `vm::destroy()` — now fetches stored `ch_api_socket`, `ch_vsock_socket`, `tap_device` from DB before calling shutdown/tap-destroy
- `vm::rename()` — allows **any** state (running or stopped); running VMs get a name-only DB update (all stored paths intact); stopped VMs also get rootfs dir + TAP renamed + paths updated
- `db::rename_vm_name_only()` — name-only DB update for running rename
- `server.rs` reconcile — uses `vm.tap_device` from DB record instead of deriving from name
- `api.rs` — `POST /api/vms/{name}/stop`
- `client.rs` + `main.rs` — `stop` command everywhere

Closes part of #8.