### PR TITLE
feat: phase 6 — SSH gateway for MINICLANKERS.COM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,54 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -80,6 +122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,16 +197,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
 
 [[package]]
 name = "bumpalo"
@@ -168,10 +275,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -196,6 +318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +339,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -255,10 +398,168 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -270,6 +571,72 @@ dependencies = [
  "quote",
  "syn 2.0.116",
 ]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -294,16 +661,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "flurry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -403,6 +814,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +852,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,12 +895,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -458,6 +929,45 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -578,7 +1088,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -672,6 +1182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +1206,28 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -735,12 +1273,27 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -787,6 +1340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +1376,7 @@ dependencies = [
  "clap",
  "libc",
  "minions-proto",
+ "minions-ssh",
  "nix",
  "reqwest",
  "rusqlite",
@@ -866,6 +1426,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "minions-ssh"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rusqlite",
+ "russh",
+ "russh-keys",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,12 +1487,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -918,6 +1564,65 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
+name = "pageant"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc"
+dependencies = [
+ "bytes",
+ "delegate",
+ "futures",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows",
+]
 
 [[package]]
 name = "papergrid"
@@ -954,6 +1659,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,10 +1696,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -993,6 +1778,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1040,7 +1844,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1055,13 +1859,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1098,12 +1902,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1113,7 +1938,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1173,6 +2007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +2028,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1201,10 +2066,157 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c536b90d8e2468d8dedc8de2369383c101325e23fffa3a30de713032862a11d4"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bitflags",
+ "byteorder",
+ "cbc",
+ "chacha20",
+ "ctr",
+ "curve25519-dalek",
+ "des",
+ "digest",
+ "elliptic-curve",
+ "flate2",
+ "futures",
+ "generic-array",
+ "hex-literal",
+ "hmac",
+ "log",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "poly1305",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "russh-cryptovec",
+ "russh-keys",
+ "russh-sftp",
+ "russh-util",
+ "sha1",
+ "sha2",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadd2c0ab350e21c66556f94ee06f766d8bdae3213857ba7610bfd8e10e51880"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "russh-keys"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3db166c8678c824627c2c46f619ed5ce4ae33f38a35403c62f6ab8f3985867"
+dependencies = [
+ "aes",
+ "async-trait",
+ "bcrypt-pbkdf",
+ "block-padding",
+ "byteorder",
+ "cbc",
+ "ctr",
+ "data-encoding",
+ "der",
+ "digest",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "futures",
+ "getrandom 0.2.17",
+ "hmac",
+ "home",
+ "inout",
+ "log",
+ "md5",
+ "num-integer",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "serde",
+ "sha1",
+ "sha2",
+ "spki",
+ "ssh-encoding",
+ "ssh-key",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "flurry",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63aeb9d2b74f8f38befdc0c5172d5ffcf58f3d2ffcb423f3b6cdfe2c2d747b80"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustls"
@@ -1254,10 +2266,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "seize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1326,6 +2384,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +2431,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +2466,73 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "bcrypt-pbkdf",
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1457,11 +2620,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1482,6 +2665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1544,6 +2736,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1672,6 +2889,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +2905,22 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -1712,6 +2951,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -1761,6 +3011,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1825,6 +3084,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,16 +3147,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1871,6 +3220,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1896,11 +3256,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2073,6 +3452,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.116",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/minions-agent",
     "crates/minions-host",
     "crates/minions",
+    "crates/minions-ssh",
 ]
 
 [workspace.dependencies]

--- a/crates/minions-ssh/Cargo.toml
+++ b/crates/minions-ssh/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "minions-ssh"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "minions_ssh"
+path = "src/lib.rs"
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+russh = "0.46"
+russh-keys = "0.46"
+async-trait = "0.1"
+rusqlite = { version = "0.32", features = ["bundled"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+chrono = "0.4"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/minions-ssh/src/commands.rs
+++ b/crates/minions-ssh/src/commands.rs
@@ -1,0 +1,393 @@
+//! Command-mode routing for the SSH gateway.
+//!
+//! Parses the command string the user typed (e.g. `ls`, `new myvm --cpus 2`)
+//! and calls the local minions HTTP API.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::db::User;
+
+/// HTTP client wrapper for the local minions API.
+pub struct ApiClient {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl ApiClient {
+    pub fn new(base_url: String, api_key: Option<String>) -> Self {
+        Self { client: reqwest::Client::new(), base_url, api_key }
+    }
+
+    fn auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(key) = &self.api_key {
+            req.bearer_auth(key)
+        } else {
+            req
+        }
+    }
+
+    pub async fn list_vms(&self) -> Result<Vec<VmInfo>> {
+        let resp = self
+            .auth(self.client.get(format!("{}/api/vms", self.base_url)))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Vec<VmInfo>>()
+            .await?;
+        Ok(resp)
+    }
+
+    pub async fn create_vm(
+        &self,
+        name: &str,
+        cpus: u32,
+        memory_mb: u32,
+    ) -> Result<VmInfo> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            name: &'a str,
+            cpus: u32,
+            memory_mb: u32,
+        }
+        let resp = self
+            .auth(
+                self.client
+                    .post(format!("{}/api/vms", self.base_url))
+                    .json(&Req { name, cpus, memory_mb }),
+            )
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<VmInfo>()
+            .await?;
+        Ok(resp)
+    }
+
+    pub async fn destroy_vm(&self, name: &str) -> Result<()> {
+        self.auth(
+            self.client
+                .delete(format!("{}/api/vms/{}", self.base_url, name)),
+        )
+        .send()
+        .await?
+        .error_for_status()?;
+        Ok(())
+    }
+
+    pub async fn stop_vm(&self, name: &str) -> Result<VmInfo> {
+        let resp = self
+            .auth(
+                self.client
+                    .post(format!("{}/api/vms/{}/stop", self.base_url, name)),
+            )
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<VmInfo>()
+            .await?;
+        Ok(resp)
+    }
+
+    pub async fn restart_vm(&self, name: &str) -> Result<VmInfo> {
+        let resp = self
+            .auth(
+                self.client
+                    .post(format!("{}/api/vms/{}/restart", self.base_url, name)),
+            )
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<VmInfo>()
+            .await?;
+        Ok(resp)
+    }
+
+    pub async fn rename_vm(&self, name: &str, new_name: &str) -> Result<()> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            new_name: &'a str,
+        }
+        self.auth(
+            self.client
+                .post(format!("{}/api/vms/{}/rename", self.base_url, name))
+                .json(&Req { new_name }),
+        )
+        .send()
+        .await?
+        .error_for_status()?;
+        Ok(())
+    }
+
+    pub async fn copy_vm(&self, name: &str, new_name: &str) -> Result<VmInfo> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            new_name: &'a str,
+        }
+        let resp = self
+            .auth(
+                self.client
+                    .post(format!("{}/api/vms/{}/copy", self.base_url, name))
+                    .json(&Req { new_name }),
+            )
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<VmInfo>()
+            .await?;
+        Ok(resp)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VmInfo {
+    pub name: String,
+    pub status: String,
+    pub ip: String,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub pid: Option<i64>,
+}
+
+// ── Command execution ──────────────────────────────────────────────────────────
+
+/// Execute a command string on behalf of `user`, returning output to send
+/// back to the SSH client. Returns `(output, exit_code)`.
+pub async fn run(
+    cmd_str: &str,
+    user: &User,
+    api: &ApiClient,
+    db_path: &str,
+) -> (String, u32) {
+    match execute(cmd_str, user, api, db_path).await {
+        Ok(output) => (output, 0),
+        Err(e) => (format!("error: {}\r\n", e), 1),
+    }
+}
+
+async fn execute(
+    cmd_str: &str,
+    user: &User,
+    api: &ApiClient,
+    db_path: &str,
+) -> Result<String> {
+    let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+    if parts.is_empty() {
+        return Ok(help());
+    }
+
+    match parts[0] {
+        // ── ls / list ──────────────────────────────────────────────────────
+        "ls" | "list" => {
+            let vms = api.list_vms().await?;
+            if vms.is_empty() {
+                return Ok("no VMs\r\n".to_string());
+            }
+            let mut out = format!(
+                "{:<12} {:<10} {:<16} {:>5} {:>10}\r\n",
+                "NAME", "STATUS", "IP", "CPUS", "MEMORY"
+            );
+            out.push_str(&"-".repeat(60));
+            out.push_str("\r\n");
+            for vm in &vms {
+                out.push_str(&format!(
+                    "{:<12} {:<10} {:<16} {:>5} {:>8} MiB\r\n",
+                    vm.name, vm.status, vm.ip, vm.cpus, vm.memory_mb,
+                ));
+            }
+            Ok(out)
+        }
+
+        // ── new ────────────────────────────────────────────────────────────
+        "new" => {
+            let mut name = uuid_name();
+            let mut cpus: u32 = 2;
+            let mut memory_mb: u32 = 1024;
+            let mut i = 1;
+            while i < parts.len() {
+                match parts[i] {
+                    "--name" | "-n" => {
+                        i += 1;
+                        if i < parts.len() {
+                            name = parts[i].to_string();
+                        }
+                    }
+                    "--cpus" | "-c" => {
+                        i += 1;
+                        if i < parts.len() {
+                            cpus = parts[i].parse().unwrap_or(2);
+                        }
+                    }
+                    "--memory" | "--mem" | "-m" => {
+                        i += 1;
+                        if i < parts.len() {
+                            memory_mb = parts[i].parse().unwrap_or(1024);
+                        }
+                    }
+                    arg if !arg.starts_with('-') => {
+                        name = parts[i].to_string();
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            let vm = api.create_vm(&name, cpus, memory_mb).await?;
+            Ok(format!(
+                "✓ VM '{}' created\r\n  IP: {}\r\n  CPUs: {}  Memory: {} MiB\r\n  SSH: ssh root@{}\r\n",
+                vm.name, vm.ip, vm.cpus, vm.memory_mb, vm.ip
+            ))
+        }
+
+        // ── rm / destroy ───────────────────────────────────────────────────
+        "rm" | "destroy" => {
+            if parts.len() < 2 {
+                return Ok("usage: rm <name>\r\n".to_string());
+            }
+            let name = parts[1];
+            api.destroy_vm(name).await?;
+            Ok(format!("✓ VM '{}' destroyed\r\n", name))
+        }
+
+        // ── stop ───────────────────────────────────────────────────────────
+        "stop" => {
+            if parts.len() < 2 {
+                return Ok("usage: stop <name>\r\n".to_string());
+            }
+            let vm = api.stop_vm(parts[1]).await?;
+            Ok(format!("✓ VM '{}' stopped\r\n", vm.name))
+        }
+
+        // ── restart ────────────────────────────────────────────────────────
+        "restart" => {
+            if parts.len() < 2 {
+                return Ok("usage: restart <name>\r\n".to_string());
+            }
+            let vm = api.restart_vm(parts[1]).await?;
+            Ok(format!("✓ VM '{}' restarted (status: {})\r\n", vm.name, vm.status))
+        }
+
+        // ── rename ─────────────────────────────────────────────────────────
+        "rename" => {
+            if parts.len() < 3 {
+                return Ok("usage: rename <old-name> <new-name>\r\n".to_string());
+            }
+            api.rename_vm(parts[1], parts[2]).await?;
+            Ok(format!("✓ VM '{}' renamed to '{}'\r\n", parts[1], parts[2]))
+        }
+
+        // ── cp / copy ──────────────────────────────────────────────────────
+        "cp" | "copy" => {
+            if parts.len() < 2 {
+                return Ok("usage: cp <source> [new-name]\r\n".to_string());
+            }
+            let source = parts[1];
+            let new_name = if parts.len() >= 3 {
+                parts[2].to_string()
+            } else {
+                let prefix = &source[..source.len().min(6)];
+                format!("{}-copy", prefix)
+            };
+            let vm = api.copy_vm(source, &new_name).await?;
+            Ok(format!(
+                "✓ VM '{}' copied to '{}'\r\n  IP: {}\r\n  SSH: ssh root@{}\r\n",
+                source, vm.name, vm.ip, vm.ip
+            ))
+        }
+
+        // ── whoami ─────────────────────────────────────────────────────────
+        "whoami" => {
+            Ok(format!(
+                "email:      {}\r\nuser-id:    {}\r\ncreated:    {}\r\n",
+                user.email, user.id, user.created_at,
+            ))
+        }
+
+        // ── ssh-key ────────────────────────────────────────────────────────
+        "ssh-key" => {
+            if parts.len() < 2 {
+                return Ok("usage: ssh-key <list|add|remove>\r\n".to_string());
+            }
+            match parts[1] {
+                "list" => {
+                    let conn = crate::db::open(db_path)?;
+                    let keys = crate::db::list_ssh_keys(&conn, &user.id)?;
+                    if keys.is_empty() {
+                        return Ok("no keys\r\n".to_string());
+                    }
+                    let mut out = String::new();
+                    for k in &keys {
+                        out.push_str(&format!("{:16}  {}\r\n", k.name, &k.fingerprint[..16]));
+                    }
+                    Ok(out)
+                }
+                "remove" => {
+                    if parts.len() < 3 {
+                        return Ok("usage: ssh-key remove <fingerprint-prefix>\r\n".to_string());
+                    }
+                    let fp_prefix = parts[2];
+                    let conn = crate::db::open(db_path)?;
+                    let keys = crate::db::list_ssh_keys(&conn, &user.id)?;
+                    let matching: Vec<_> = keys
+                        .iter()
+                        .filter(|k| k.fingerprint.starts_with(fp_prefix))
+                        .collect();
+                    match matching.len() {
+                        0 => Ok(format!("no key matching '{}'\r\n", fp_prefix)),
+                        1 => {
+                            if crate::db::remove_ssh_key(&conn, &user.id, &matching[0].fingerprint)? {
+                                Ok(format!("✓ key '{}' removed\r\n", matching[0].name))
+                            } else {
+                                Ok("key not found\r\n".to_string())
+                            }
+                        }
+                        n => Ok(format!(
+                            "{} keys match prefix '{}'; be more specific\r\n",
+                            n, fp_prefix
+                        )),
+                    }
+                }
+                _ => Ok("usage: ssh-key <list|remove>\r\n".to_string()),
+            }
+        }
+
+        // ── help ───────────────────────────────────────────────────────────
+        "help" | "--help" | "-h" => Ok(help()),
+
+        // ── unknown ────────────────────────────────────────────────────────
+        unknown => Ok(format!(
+            "unknown command '{}'. Type 'help' for available commands.\r\n",
+            unknown
+        )),
+    }
+}
+
+fn help() -> String {
+    [
+        "MINICLANKERS.COM — VM management",
+        "",
+        "  ls                              list VMs",
+        "  new [name] [--cpus N] [--mem M] create a new VM",
+        "  rm <name>                       destroy a VM",
+        "  stop <name>                     stop a VM (keep rootfs)",
+        "  restart <name>                  reboot a running VM",
+        "  rename <old> <new>              rename a stopped VM",
+        "  cp <source> [new-name]          copy a VM",
+        "",
+        "  whoami                          show your account info",
+        "  ssh-key list                    list your registered SSH keys",
+        "  ssh-key remove <prefix>         remove an SSH key",
+        "",
+        "  help                            show this help",
+        "",
+        "  SSH into a VM:  ssh <vmname>@ssh.miniclankers.com",
+        "",
+    ]
+    .join("\r\n")
+}
+
+/// Generate a short random VM name (6 hex chars).
+fn uuid_name() -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    id[..6].to_string()
+}

--- a/crates/minions-ssh/src/db.rs
+++ b/crates/minions-ssh/src/db.rs
@@ -1,0 +1,182 @@
+//! User and SSH key management for the SSH gateway.
+//!
+//! Uses the same SQLite file as the main daemon (`/var/lib/minions/state.db`).
+//! Adds two extra tables (`users`, `ssh_keys`) that only the SSH gateway touches.
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct User {
+    pub id: String,
+    pub email: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SshKey {
+    pub id: String,
+    pub user_id: String,
+    pub public_key: String,
+    pub fingerprint: String,
+    pub name: String,
+    pub created_at: String,
+}
+
+// ── Migration ─────────────────────────────────────────────────────────────────
+
+/// Ensure the SSH gateway tables exist.
+/// Call this once at gateway startup (after the main daemon has run its migrations).
+pub fn migrate(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS users (
+            id          TEXT PRIMARY KEY,
+            email       TEXT UNIQUE NOT NULL,
+            created_at  TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS ssh_keys (
+            id          TEXT PRIMARY KEY,
+            user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            public_key  TEXT NOT NULL,
+            fingerprint TEXT UNIQUE NOT NULL,
+            name        TEXT NOT NULL DEFAULT 'default',
+            created_at  TEXT NOT NULL
+        );
+        ",
+    )
+    .context("ssh gateway migration")
+}
+
+// ── Open ──────────────────────────────────────────────────────────────────────
+
+pub fn open(path: &str) -> Result<Connection> {
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create db dir {:?}", parent))?;
+    }
+    let conn = Connection::open(path).context("open sqlite db")?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+        .context("set pragmas")?;
+    migrate(&conn)?;
+    Ok(conn)
+}
+
+// ── User operations ───────────────────────────────────────────────────────────
+
+/// Look up a registered user by SSH key fingerprint.
+pub fn get_user_by_fingerprint(conn: &Connection, fingerprint: &str) -> Result<Option<User>> {
+    let mut stmt = conn.prepare(
+        "SELECT u.id, u.email, u.created_at
+         FROM users u
+         JOIN ssh_keys k ON k.user_id = u.id
+         WHERE k.fingerprint = ?1",
+    )?;
+    let mut rows = stmt.query(params![fingerprint])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(User {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            created_at: row.get(2)?,
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Create a new user, associating their SSH public key.
+pub fn create_user(
+    conn: &Connection,
+    email: &str,
+    public_key: &str,
+    fingerprint: &str,
+) -> Result<User> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let key_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO users (id, email, created_at) VALUES (?1, ?2, ?3)",
+        params![user_id, email, now],
+    )
+    .context("insert user")?;
+
+    conn.execute(
+        "INSERT INTO ssh_keys (id, user_id, public_key, fingerprint, name, created_at)
+         VALUES (?1, ?2, ?3, ?4, 'default', ?5)",
+        params![key_id, user_id, public_key, fingerprint, now],
+    )
+    .context("insert ssh key")?;
+
+    Ok(User { id: user_id, email: email.to_string(), created_at: now })
+}
+
+/// Get a user by their ID.
+pub fn get_user(conn: &Connection, id: &str) -> Result<Option<User>> {
+    let mut stmt =
+        conn.prepare("SELECT id, email, created_at FROM users WHERE id = ?1")?;
+    let mut rows = stmt.query(params![id])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(User {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            created_at: row.get(2)?,
+        })),
+        None => Ok(None),
+    }
+}
+
+/// List all SSH keys for a user.
+pub fn list_ssh_keys(conn: &Connection, user_id: &str) -> Result<Vec<SshKey>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, user_id, public_key, fingerprint, name, created_at
+         FROM ssh_keys WHERE user_id = ?1 ORDER BY created_at",
+    )?;
+    let rows = stmt.query_map(params![user_id], |row| {
+        Ok(SshKey {
+            id: row.get(0)?,
+            user_id: row.get(1)?,
+            public_key: row.get(2)?,
+            fingerprint: row.get(3)?,
+            name: row.get(4)?,
+            created_at: row.get(5)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().context("list ssh keys")
+}
+
+/// Add an additional SSH key to an existing user.
+pub fn add_ssh_key(
+    conn: &Connection,
+    user_id: &str,
+    public_key: &str,
+    fingerprint: &str,
+    name: &str,
+) -> Result<SshKey> {
+    let key_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO ssh_keys (id, user_id, public_key, fingerprint, name, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![key_id, user_id, public_key, fingerprint, name, now],
+    )
+    .context("insert ssh key")?;
+    Ok(SshKey {
+        id: key_id,
+        user_id: user_id.to_string(),
+        public_key: public_key.to_string(),
+        fingerprint: fingerprint.to_string(),
+        name: name.to_string(),
+        created_at: now,
+    })
+}
+
+/// Remove an SSH key by fingerprint (only if it belongs to the given user).
+pub fn remove_ssh_key(conn: &Connection, user_id: &str, fingerprint: &str) -> Result<bool> {
+    let changed = conn.execute(
+        "DELETE FROM ssh_keys WHERE user_id = ?1 AND fingerprint = ?2",
+        params![user_id, fingerprint],
+    )?;
+    Ok(changed > 0)
+}

--- a/crates/minions-ssh/src/lib.rs
+++ b/crates/minions-ssh/src/lib.rs
@@ -1,0 +1,149 @@
+//! `minions-ssh` — SSH gateway for MINICLANKERS.COM.
+//!
+//! Provides two modes on a single port:
+//!
+//! * **Command mode** — `ssh minions@ssh.miniclankers.com [command]`
+//!   Authenticated by public key. Unregistered users are prompted for an email.
+//!   Commands map to the local minions HTTP API.
+//!
+//! * **Proxy mode** — `ssh <vmname>@ssh.miniclankers.com`
+//!   The gateway authenticates to the VM's sshd using the gateway's own proxy
+//!   key (injected into every VM's `/root/.ssh/authorized_keys` at creation).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use russh::server::Server as _;
+use russh_keys::key::KeyPair;
+use tracing::info;
+
+pub mod commands;
+pub mod db;
+pub mod proxy;
+pub mod server;
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// Configuration for the SSH gateway.
+#[derive(Clone)]
+pub struct GatewayConfig {
+    /// Path to the SQLite state DB (shared with the main daemon).
+    pub db_path: String,
+    /// SSH username that triggers command mode (e.g. "minions").
+    pub command_user: String,
+    /// Base URL of the local minions HTTP API (e.g. "http://127.0.0.1:3000").
+    pub api_base_url: String,
+    /// API key for the minions HTTP API (if MINIONS_API_KEY is set).
+    pub api_key: Option<String>,
+    /// Gateway proxy key used to authenticate to VMs.
+    pub proxy_key: Arc<KeyPair>,
+}
+
+// ── Key paths ─────────────────────────────────────────────────────────────────
+
+pub const HOST_KEY_PATH: &str = "/var/lib/minions/ssh_host_key";
+pub const PROXY_KEY_PATH: &str = "/var/lib/minions/proxy_key";
+pub const PROXY_PUBKEY_PATH: &str = "/var/lib/minions/proxy_key.pub";
+
+// ── Key management ────────────────────────────────────────────────────────────
+
+/// Generate the SSH host key and proxy key if they don't exist yet.
+/// Returns `(host_key, proxy_key, proxy_pubkey_openssh)`.
+pub fn ensure_keys() -> Result<(KeyPair, KeyPair, String)> {
+    let host_key = ensure_key(HOST_KEY_PATH).context("host key")?;
+    let (proxy_key, proxy_pubkey) = ensure_proxy_key(PROXY_KEY_PATH, PROXY_PUBKEY_PATH)
+        .context("proxy key")?;
+    Ok((host_key, proxy_key, proxy_pubkey))
+}
+
+fn ensure_key(path: &str) -> Result<KeyPair> {
+    if std::path::Path::new(path).exists() {
+        let kp = russh_keys::load_secret_key(path, None)
+            .with_context(|| format!("load key from {}", path))?;
+        return Ok(kp);
+    }
+    // Generate with ssh-keygen — most reliable across platforms.
+    generate_ed25519_key(path)?;
+    let kp = russh_keys::load_secret_key(path, None)
+        .with_context(|| format!("load generated key from {}", path))?;
+    info!("generated new SSH host key at {}", path);
+    Ok(kp)
+}
+
+fn ensure_proxy_key(key_path: &str, pub_path: &str) -> Result<(KeyPair, String)> {
+    if std::path::Path::new(key_path).exists() {
+        let kp = russh_keys::load_secret_key(key_path, None)
+            .with_context(|| format!("load proxy key from {}", key_path))?;
+        let pubkey = std::fs::read_to_string(pub_path)
+            .with_context(|| format!("read proxy pubkey from {}", pub_path))?;
+        return Ok((kp, pubkey.trim().to_string()));
+    }
+    // Generate key pair.
+    generate_ed25519_key(key_path)?;
+    // Write public key.
+    let kp = russh_keys::load_secret_key(key_path, None)
+        .with_context(|| format!("load generated proxy key from {}", key_path))?;
+    let pubkey_str = public_key_openssh_line(&kp);
+    std::fs::write(pub_path, format!("{}\n", pubkey_str))
+        .with_context(|| format!("write proxy pubkey to {}", pub_path))?;
+    info!("generated new proxy key at {}", key_path);
+    info!("proxy public key: {}", pubkey_str);
+    Ok((kp, pubkey_str))
+}
+
+/// Run `ssh-keygen -t ed25519 -f <path> -N ""` to generate a key.
+fn generate_ed25519_key(path: &str) -> Result<()> {
+    // Ensure parent directory exists.
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let status = std::process::Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-f", path, "-N", ""])
+        .status()
+        .context("run ssh-keygen (is openssh installed?)")?;
+    if !status.success() {
+        anyhow::bail!("ssh-keygen failed for {}", path);
+    }
+    // Remove the .pub file ssh-keygen creates (we manage pubkeys ourselves).
+    let _ = std::fs::remove_file(format!("{}.pub", path));
+    Ok(())
+}
+
+/// Format the gateway's proxy key as an OpenSSH authorized_keys line.
+pub fn public_key_openssh_line(kp: &KeyPair) -> String {
+    use russh_keys::PublicKeyBase64;
+    let pk = kp.clone_public_key().expect("clone public key");
+    format!("{} {} minions-gateway", pk.name(), pk.public_key_base64())
+}
+
+// ── Serve ─────────────────────────────────────────────────────────────────────
+
+/// Start the SSH gateway.
+///
+/// `host_key`   — server host key (identifies the gateway to clients)
+/// `proxy_key`  — key used by the gateway to authenticate to VMs
+/// `bind`       — address + port to listen on (e.g. "0.0.0.0:22")
+/// `config`     — gateway config
+pub async fn serve(
+    host_key: KeyPair,
+    config: GatewayConfig,
+    bind: &str,
+) -> Result<()> {
+    let russh_config = Arc::new(russh::server::Config {
+        keys: vec![host_key],
+        inactivity_timeout: Some(std::time::Duration::from_secs(3600)),
+        auth_rejection_time: std::time::Duration::from_millis(300),
+        auth_rejection_time_initial: Some(std::time::Duration::from_secs(0)),
+        ..Default::default()
+    });
+
+    let mut srv = server::SshServer { config: Arc::new(config) };
+
+    let addr: std::net::SocketAddr = bind.parse()
+        .with_context(|| format!("parse bind address: {}", bind))?;
+
+    info!("SSH gateway listening on {}", bind);
+    srv.run_on_address(russh_config, addr)
+        .await
+        .context("SSH gateway error")
+}

--- a/crates/minions-ssh/src/proxy.rs
+++ b/crates/minions-ssh/src/proxy.rs
@@ -1,0 +1,142 @@
+//! SSH proxy mode: bridge an incoming SSH session to a VM's sshd.
+//!
+//! When a user connects as `<vmname>@ssh.miniclankers.com`, we:
+//! 1. Open a russh client connection to the VM's internal IP on port 22.
+//! 2. Authenticate as `root` using the gateway's proxy key pair.
+//! 3. Bridge channel data between the client and the VM using `ChannelStream`.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use russh::{ChannelId, Pty};
+use russh::client;
+use russh_keys::key::{KeyPair, PublicKey};
+use tokio::io::AsyncReadExt;
+use tracing::debug;
+
+use crate::server::ServerHandle;
+
+// ── Minimal russh client Handler ──────────────────────────────────────────────
+
+pub struct VmClientHandler;
+
+#[async_trait::async_trait]
+impl client::Handler for VmClientHandler {
+    type Error = anyhow::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _server_public_key: &PublicKey,
+    ) -> Result<bool, Self::Error> {
+        // Always trust VMs on the internal (trusted) network.
+        Ok(true)
+    }
+}
+
+// ── ConnectedVm ───────────────────────────────────────────────────────────────
+
+/// An established SSH session to a VM.
+pub struct ConnectedVm {
+    pub channel: russh::Channel<client::Msg>,
+}
+
+impl ConnectedVm {
+    /// Connect to `vm_ip:22` and authenticate as root with `proxy_key`.
+    pub async fn connect(vm_ip: &str, proxy_key: Arc<KeyPair>) -> Result<Self> {
+        let config = Arc::new(client::Config::default());
+        let addr = format!("{}:22", vm_ip);
+
+        let mut session = client::connect(config, addr.as_str(), VmClientHandler)
+            .await
+            .with_context(|| format!("connect to VM SSH at {}", addr))?;
+
+        let authed = session
+            .authenticate_publickey("root", proxy_key)
+            .await
+            .context("proxy key auth to VM")?;
+
+        if !authed {
+            anyhow::bail!(
+                "gateway proxy key rejected by VM '{}'\n\
+                 Hint: recreate the VM after running `minions serve --ssh-bind` \
+                 at least once to generate the proxy key.",
+                vm_ip
+            );
+        }
+
+        let channel = session
+            .channel_open_session()
+            .await
+            .context("open session channel on VM")?;
+
+        // Drive the session in a background task; the channel keeps it alive.
+        tokio::spawn(async move {
+            if let Err(e) = session.await {
+                debug!("VM client session ended: {}", e);
+            }
+        });
+
+        Ok(ConnectedVm { channel })
+    }
+
+    /// Request a PTY on the VM channel.
+    pub async fn request_pty(
+        &mut self,
+        term: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        modes: &[(Pty, u32)],
+    ) -> Result<()> {
+        self.channel
+            .request_pty(true, term, col_width, row_height, pix_width, pix_height, modes)
+            .await
+            .context("pty_request to VM")
+    }
+
+    /// Request an interactive shell on the VM.
+    pub async fn request_shell(&mut self) -> Result<()> {
+        self.channel.request_shell(true).await.context("shell_request to VM")
+    }
+
+    /// Execute a command on the VM.
+    pub async fn exec(&mut self, command: &[u8]) -> Result<()> {
+        self.channel.exec(true, command).await.context("exec on VM")
+    }
+}
+
+// ── Bidirectional proxy ────────────────────────────────────────────────────────
+
+/// Takes ownership of the VM channel, converts it to a stream, and:
+/// * spawns a task that forwards VM stdout → client (via `client_handle`)
+/// * returns the write half so the caller can forward client stdin → VM.
+///
+/// The returned writer implements `AsyncWrite + Send + Unpin`.
+pub fn spawn_proxy(
+    vm: ConnectedVm,
+    client_handle: ServerHandle,
+    client_channel_id: ChannelId,
+) -> tokio::io::WriteHalf<russh::ChannelStream<client::Msg>> {
+    let stream = vm.channel.into_stream();
+    let (mut read_half, write_half) = tokio::io::split(stream);
+
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 32_768];
+        loop {
+            match read_half.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let data = russh::CryptoVec::from(buf[..n].to_vec());
+                    if client_handle.data(client_channel_id, data).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+        let _ = client_handle.eof(client_channel_id).await;
+        let _ = client_handle.close(client_channel_id).await;
+    });
+
+    write_half
+}

--- a/crates/minions-ssh/src/server.rs
+++ b/crates/minions-ssh/src/server.rs
@@ -1,0 +1,556 @@
+//! russh Server + Handler implementation for the SSH gateway.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::Result;
+use russh::{Channel, ChannelId, CryptoVec, Pty};
+use russh::server::{Auth, Handler, Msg, Session};
+use russh_keys::key::PublicKey;
+use russh_keys::PublicKeyBase64;
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, info};
+
+use crate::commands::ApiClient;
+use crate::db::User;
+use crate::proxy::{ConnectedVm, spawn_proxy};
+
+/// The server::Handle type (used to write back to the SSH client from async tasks).
+pub type ServerHandle = russh::server::Handle;
+
+// ── Session mode ──────────────────────────────────────────────────────────────
+
+enum SessionMode {
+    /// Not yet determined (between auth and first channel request).
+    Pending,
+    /// Collecting the user's email for first-time registration.
+    Registration { after: AfterRegistration, email_buf: String },
+    /// Registered user in interactive command mode.
+    Command { line_buf: String },
+    /// Proxy mode: stdin bytes go to the VM via this writer.
+    Proxy { vm_stdin: tokio::io::WriteHalf<russh::ChannelStream<russh::client::Msg>> },
+}
+
+#[derive(Clone)]
+enum AfterRegistration {
+    Command,
+    Proxy { vm_name: String },
+}
+
+// ── PTY params (stored during pty_request, forwarded on shell/exec) ───────────
+
+#[derive(Default, Clone)]
+struct PtyParams {
+    term: String,
+    col_width: u32,
+    row_height: u32,
+    pix_width: u32,
+    pix_height: u32,
+    modes: Vec<(Pty, u32)>,
+}
+
+// ── Connection handler ────────────────────────────────────────────────────────
+
+pub struct ConnectionHandler {
+    config: Arc<crate::GatewayConfig>,
+    peer_addr: Option<SocketAddr>,
+
+    /// SSH username the client used (e.g. "minions" or a VM name).
+    ssh_username: String,
+    /// The public key presented during auth.
+    pending_key: Option<PublicKey>,
+    /// Set when the key matches a registered user.
+    authed_user: Option<User>,
+
+    /// Set in channel_open_session.
+    client_handle: Option<ServerHandle>,
+    client_channel_id: Option<ChannelId>,
+
+    /// Stored between pty_request and shell/exec_request.
+    pty: Option<PtyParams>,
+
+    /// Current session state.
+    mode: SessionMode,
+}
+
+impl ConnectionHandler {
+    pub fn new(config: Arc<crate::GatewayConfig>, peer_addr: Option<SocketAddr>) -> Self {
+        Self {
+            config,
+            peer_addr,
+            ssh_username: String::new(),
+            pending_key: None,
+            authed_user: None,
+            client_handle: None,
+            client_channel_id: None,
+            pty: None,
+            mode: SessionMode::Pending,
+        }
+    }
+
+    fn api(&self) -> ApiClient {
+        ApiClient::new(self.config.api_base_url.clone(), self.config.api_key.clone())
+    }
+
+    fn fingerprint(key: &PublicKey) -> String {
+        key.fingerprint()
+    }
+
+    fn key_to_str(key: &PublicKey) -> String {
+        format!("{} {}", key.name(), key.public_key_base64())
+    }
+
+    async fn send(&self, bytes: impl Into<Vec<u8>>) {
+        if let (Some(h), Some(id)) = (&self.client_handle, self.client_channel_id) {
+            let _ = h.data(id, CryptoVec::from(bytes.into())).await;
+        }
+    }
+
+    async fn close_err(&self, msg: &str) {
+        self.send(format!("error: {}\r\n", msg)).await;
+        if let (Some(h), Some(id)) = (&self.client_handle, self.client_channel_id) {
+            let _ = h.exit_status_request(id, 1).await;
+            let _ = h.eof(id).await;
+            let _ = h.close(id).await;
+        }
+    }
+
+    /// Look up a VM by name via the API and return its IP.
+    async fn resolve_vm(&self, vm_name: &str) -> Result<String> {
+        let vms = self.api().list_vms().await?;
+        let vm = vms
+            .into_iter()
+            .find(|v| v.name == vm_name)
+            .ok_or_else(|| anyhow::anyhow!("VM '{}' not found", vm_name))?;
+        if vm.status != "running" {
+            anyhow::bail!("VM '{}' is {} — it must be running to SSH into it", vm_name, vm.status);
+        }
+        Ok(vm.ip)
+    }
+
+    /// Connect to a VM and set up the bidirectional proxy.
+    /// Sends the shell or exec request on the VM channel.
+    async fn start_proxy_shell(&mut self, vm_name: &str) -> Result<()> {
+        let vm_ip = self.resolve_vm(vm_name).await?;
+        let mut vm = ConnectedVm::connect(&vm_ip, Arc::clone(&self.config.proxy_key)).await?;
+
+        // Forward PTY if the client requested one.
+        if let Some(ref pty) = self.pty.clone() {
+            vm.request_pty(
+                &pty.term,
+                pty.col_width,
+                pty.row_height,
+                pty.pix_width,
+                pty.pix_height,
+                &pty.modes,
+            )
+            .await?;
+        }
+
+        vm.request_shell().await?;
+
+        let handle = self.client_handle.clone().expect("handle set");
+        let cid = self.client_channel_id.expect("cid set");
+        let vm_stdin = spawn_proxy(vm, handle, cid);
+        self.mode = SessionMode::Proxy { vm_stdin };
+        Ok(())
+    }
+
+    async fn start_proxy_exec(&mut self, vm_name: &str, command: &[u8]) -> Result<()> {
+        let vm_ip = self.resolve_vm(vm_name).await?;
+        let mut vm = ConnectedVm::connect(&vm_ip, Arc::clone(&self.config.proxy_key)).await?;
+        vm.exec(command).await?;
+
+        let handle = self.client_handle.clone().expect("handle set");
+        let cid = self.client_channel_id.expect("cid set");
+        let vm_stdin = spawn_proxy(vm, handle, cid);
+        self.mode = SessionMode::Proxy { vm_stdin };
+        Ok(())
+    }
+
+    async fn complete_registration(
+        &mut self,
+        email: String,
+        after: AfterRegistration,
+        session: &mut Session,
+        channel: ChannelId,
+    ) -> Result<()> {
+        session.data(channel, CryptoVec::from(b"\r\n".to_vec()));
+
+        if !email.contains('@') || email.len() < 5 {
+            session.data(
+                channel,
+                CryptoVec::from(b"Invalid email. Try again: ".to_vec()),
+            );
+            if let SessionMode::Registration { email_buf, .. } = &mut self.mode {
+                email_buf.clear();
+            }
+            return Ok(());
+        }
+
+        let key = self.pending_key.clone().expect("pending key set");
+        let fp = Self::fingerprint(&key);
+        let key_str = Self::key_to_str(&key);
+
+        let conn = crate::db::open(&self.config.db_path)?;
+        match crate::db::create_user(&conn, &email, &key_str, &fp) {
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("UNIQUE") {
+                    session.data(
+                        channel,
+                        CryptoVec::from(
+                            "Email already registered — use the key that belongs to that account.\r\n"
+                                .as_bytes()
+                                .to_vec(),
+                        ),
+                    );
+                } else {
+                    session.data(
+                        channel,
+                        CryptoVec::from(format!("Registration error: {}\r\n", msg).into_bytes()),
+                    );
+                }
+                return Ok(());
+            }
+            Ok(user) => {
+                self.authed_user = Some(user.clone());
+                info!(email = %user.email, peer = ?self.peer_addr, "new user registered");
+                session.data(
+                    channel,
+                    CryptoVec::from(
+                        format!("✓ Registered! Welcome, {}.\r\n\r\n", user.email).into_bytes(),
+                    ),
+                );
+            }
+        }
+
+        match after {
+            AfterRegistration::Command => {
+                self.mode = SessionMode::Command { line_buf: String::new() };
+                session.data(
+                    channel,
+                    CryptoVec::from(b"Type 'help' for available commands.\r\n\r\n$ ".to_vec()),
+                );
+            }
+            AfterRegistration::Proxy { vm_name } => {
+                match self.start_proxy_shell(&vm_name).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        session.data(
+                            channel,
+                            CryptoVec::from(format!("error: {}\r\n", e).into_bytes()),
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── russh Handler impl ────────────────────────────────────────────────────────
+
+#[async_trait::async_trait]
+impl Handler for ConnectionHandler {
+    type Error = anyhow::Error;
+
+    async fn auth_publickey(
+        &mut self,
+        user: &str,
+        public_key: &PublicKey,
+    ) -> Result<Auth, Self::Error> {
+        self.ssh_username = user.to_string();
+        self.pending_key = Some(public_key.clone());
+
+        let fp = Self::fingerprint(public_key);
+        let conn = crate::db::open(&self.config.db_path)?;
+        self.authed_user = crate::db::get_user_by_fingerprint(&conn, &fp)?;
+
+        if let Some(ref u) = self.authed_user {
+            info!(peer = ?self.peer_addr, email = %u.email, "authenticated");
+        } else {
+            info!(peer = ?self.peer_addr, ssh_user = %user, "unknown key — will prompt for registration");
+        }
+
+        Ok(Auth::Accept)
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        channel: Channel<Msg>,
+        session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        self.client_handle = Some(session.handle());
+        self.client_channel_id = Some(channel.id());
+        debug!(peer = ?self.peer_addr, channel = ?channel.id(), "session opened");
+        Ok(true)
+    }
+
+    async fn pty_request(
+        &mut self,
+        channel: ChannelId,
+        term: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        modes: &[(Pty, u32)],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        session.channel_success(channel);
+        self.pty = Some(PtyParams {
+            term: term.to_string(),
+            col_width,
+            row_height,
+            pix_width,
+            pix_height,
+            modes: modes.to_vec(),
+        });
+        Ok(())
+    }
+
+    async fn shell_request(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        session.channel_success(channel);
+
+        let is_proxy = self.ssh_username != self.config.command_user;
+
+        // Unregistered user → prompt for email.
+        if self.authed_user.is_none() {
+            let after = if is_proxy {
+                AfterRegistration::Proxy { vm_name: self.ssh_username.clone() }
+            } else {
+                AfterRegistration::Command
+            };
+            self.mode = SessionMode::Registration { after, email_buf: String::new() };
+            session.data(
+                channel,
+                CryptoVec::from(
+                    b"Welcome to MINICLANKERS.COM\r\n\r\nEnter your email to register: ".to_vec(),
+                ),
+            );
+            return Ok(());
+        }
+
+        let user = self.authed_user.clone().unwrap();
+
+        if is_proxy {
+            let vm_name = self.ssh_username.clone();
+            match self.start_proxy_shell(&vm_name).await {
+                Ok(()) => {}
+                Err(e) => self.close_err(&e.to_string()).await,
+            }
+        } else {
+            // Command mode: interactive shell.
+            self.mode = SessionMode::Command { line_buf: String::new() };
+            let banner = format!(
+                "MINICLANKERS.COM — logged in as {}\r\nType 'help' for commands.\r\n\r\n$ ",
+                user.email
+            );
+            session.data(channel, CryptoVec::from(banner.into_bytes()));
+        }
+        Ok(())
+    }
+
+    async fn exec_request(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        session.channel_success(channel);
+        let cmd_str = String::from_utf8_lossy(data).to_string();
+
+        // Unregistered user — must register interactively first.
+        if self.authed_user.is_none() {
+            let msg = "Register first: ssh minions@ssh.miniclankers.com\r\n";
+            let _ = session.data(channel, CryptoVec::from(msg.as_bytes().to_vec()));
+            session.exit_status_request(channel, 1);
+            session.eof(channel);
+            session.close(channel);
+            return Ok(());
+        }
+
+        let user = self.authed_user.clone().unwrap();
+        let is_proxy = self.ssh_username != self.config.command_user;
+
+        if is_proxy {
+            let vm_name = self.ssh_username.clone();
+            match self.start_proxy_exec(&vm_name, data).await {
+                Ok(()) => {}
+                Err(e) => self.close_err(&e.to_string()).await,
+            }
+            return Ok(());
+        }
+
+        // Command mode exec: run command, return output, exit.
+        let api = self.api();
+        let db_path = self.config.db_path.clone();
+        let (output, code) = crate::commands::run(&cmd_str, &user, &api, &db_path).await;
+        session.data(channel, CryptoVec::from(output.into_bytes()));
+        session.exit_status_request(channel, code);
+        session.eof(channel);
+        session.close(channel);
+        Ok(())
+    }
+
+    async fn data(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        // ── Registration: collect email ───────────────────────────────────────
+        // Inner block releases the mutable borrow before calling complete_registration.
+        let reg_action: Option<(String, AfterRegistration)> = {
+            if let SessionMode::Registration { email_buf, after } = &mut self.mode {
+                let mut action = None;
+                for &b in data {
+                    match b {
+                        b'\r' | b'\n' => {
+                            let email = email_buf.trim().to_lowercase();
+                            action = Some((email, after.clone()));
+                            break;
+                        }
+                        0x7f | 0x08 => {
+                            if !email_buf.is_empty() {
+                                email_buf.pop();
+                                session.data(channel, CryptoVec::from(b"\x08 \x08".to_vec()));
+                            }
+                        }
+                        c => {
+                            email_buf.push(c as char);
+                            session.data(channel, CryptoVec::from(vec![c]));
+                        }
+                    }
+                }
+                action
+            } else {
+                None
+            }
+        }; // ← mutable borrow released here
+        if let Some((email, after)) = reg_action {
+            self.complete_registration(email, after, session, channel).await?;
+            return Ok(());
+        }
+        if matches!(self.mode, SessionMode::Registration { .. }) {
+            return Ok(()); // still collecting input, no newline yet
+        }
+
+        // ── Proxy: forward stdin to VM ────────────────────────────────────────
+        if let SessionMode::Proxy { vm_stdin } = &mut self.mode {
+            if let Err(e) = vm_stdin.write_all(data).await {
+                debug!("proxy stdin write error: {}", e);
+            }
+            return Ok(()); // borrow of vm_stdin ends here, before any &self call
+        }
+
+        // ── Command: line-buffered shell ──────────────────────────────────────
+        // Use an inner block so the mutable borrow of self.mode is released
+        // before we call self.api() (which needs &self).
+        let ready_cmds: Vec<String> = {
+            match &mut self.mode {
+                SessionMode::Command { line_buf } => {
+                    let mut cmds = Vec::new();
+                    let input = String::from_utf8_lossy(data).to_string();
+                    for ch in input.chars() {
+                        match ch {
+                            '\r' | '\n' => {
+                                let cmd = line_buf.trim().to_string();
+                                line_buf.clear();
+                                if cmd.is_empty() {
+                                    session.data(channel, CryptoVec::from(b"$ ".to_vec()));
+                                } else {
+                                    cmds.push(cmd);
+                                }
+                            }
+                            '\x08' | '\x7f' => {
+                                if !line_buf.is_empty() {
+                                    line_buf.pop();
+                                    session.data(channel, CryptoVec::from(b"\x08 \x08".to_vec()));
+                                }
+                            }
+                            c => {
+                                line_buf.push(c);
+                                session.data(
+                                    channel,
+                                    CryptoVec::from(c.to_string().into_bytes()),
+                                );
+                            }
+                        }
+                    }
+                    cmds
+                }
+                // All other modes already handled above; this is unreachable.
+                _ => vec![],
+            }
+        }; // ← mutable borrow of self.mode released here
+
+        // Execute collected commands (self is freely borrowable again).
+        if !ready_cmds.is_empty() {
+            if let Some(user) = self.authed_user.clone() {
+                let api = self.api();
+                let db_path = self.config.db_path.clone();
+                for cmd in ready_cmds {
+                    let (output, _) = crate::commands::run(&cmd, &user, &api, &db_path).await;
+                    session.data(channel, CryptoVec::from(output.into_bytes()));
+                    session.data(channel, CryptoVec::from(b"$ ".to_vec()));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn window_change_request(
+        &mut self,
+        _channel: ChannelId,
+        _col_width: u32,
+        _row_height: u32,
+        _pix_width: u32,
+        _pix_height: u32,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        // Window changes for the proxy mode would require forwarding to the VM channel.
+        // The vm_channel was moved into spawn_proxy; a follow-up could add a control
+        // channel for window changes. Accepted limitation for phase 6.
+        Ok(())
+    }
+
+    async fn channel_close(
+        &mut self,
+        _channel: ChannelId,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        debug!(peer = ?self.peer_addr, "channel_close");
+        Ok(())
+    }
+
+    async fn channel_eof(
+        &mut self,
+        _channel: ChannelId,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        debug!(peer = ?self.peer_addr, "channel_eof");
+        Ok(())
+    }
+}
+
+// ── Server factory ────────────────────────────────────────────────────────────
+
+pub struct SshServer {
+    pub config: Arc<crate::GatewayConfig>,
+}
+
+#[async_trait::async_trait]
+impl russh::server::Server for SshServer {
+    type Handler = ConnectionHandler;
+
+    fn new_client(&mut self, peer_addr: Option<SocketAddr>) -> ConnectionHandler {
+        ConnectionHandler::new(Arc::clone(&self.config), peer_addr)
+    }
+}

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "minions"
 path = "src/main.rs"
 
+[dependencies.minions-ssh]
+path = "../minions-ssh"
+
 [dependencies]
 minions-proto = { path = "../minions-proto" }
 tokio = { workspace = true }

--- a/docs/phase-6-setup.md
+++ b/docs/phase-6-setup.md
@@ -1,0 +1,296 @@
+# Phase 6 — SSH Gateway
+
+Phase 6 adds an SSH gateway that makes VMs accessible over SSH using your domain
+(**MINICLANKERS.COM**) without needing to know each VM's internal IP.
+
+Two modes run on a single port (22):
+
+| Mode | Command | What it does |
+|------|---------|--------------|
+| **Command** | `ssh minions@ssh.miniclankers.com` | Manage VMs (ls, new, rm, …) |
+| **Proxy** | `ssh vmname@ssh.miniclankers.com` | SSH directly into VM |
+
+First-time users are prompted for an email address to register.
+
+---
+
+## 1. Cloudflare DNS Setup
+
+Add these records in the Cloudflare dashboard for MINICLANKERS.COM:
+
+| Type | Name | Value | Proxy |
+|------|------|-------|-------|
+| A | `ssh` | `<your host IP>` | **DNS only** (grey cloud) |
+| A | `@` | `<your host IP>` | DNS only |
+
+> **Important**: keep the proxy **off** (grey cloud) for port 22 — Cloudflare
+> doesn't proxy raw TCP/SSH traffic on arbitrary ports.
+
+---
+
+## 2. Host Setup
+
+### 2a. Allow port 22 binding without root
+
+The `minions` binary needs to listen on port 22. Two options:
+
+**Option A — Run as root** (simplest, fine for a dedicated server):
+```bash
+sudo minions serve --bind 0.0.0.0:3000 --ssh-bind 0.0.0.0:22
+```
+
+**Option B — `CAP_NET_BIND_SERVICE` capability** (run as non-root):
+```bash
+sudo setcap cap_net_bind_service=+ep /usr/local/bin/minions
+# Now minions can bind port 22 as a normal user
+minions serve --bind 0.0.0.0:3000 --ssh-bind 0.0.0.0:22
+```
+
+**Option C — Move host SSH to a different port** (if you SSH into the host itself):
+```bash
+# In /etc/ssh/sshd_config, change Port 22 → Port 2222, then:
+sudo systemctl restart sshd
+# Now port 22 is free for minions
+sudo minions serve --bind 0.0.0.0:3000 --ssh-bind 0.0.0.0:22
+```
+
+### 2b. First run — key generation
+
+On the first run with `--ssh-bind`, minions generates two key files:
+
+| File | Purpose |
+|------|---------|
+| `/var/lib/minions/ssh_host_key` | SSH host key (identifies the gateway to clients) |
+| `/var/lib/minions/proxy_key` | Private key used to authenticate to VMs |
+| `/var/lib/minions/proxy_key.pub` | Public key injected into every new VM |
+
+These are generated automatically — no manual step required.
+
+### 2c. Systemd service update
+
+Update `/etc/systemd/system/minions.service` to add `--ssh-bind`:
+
+```ini
+[Unit]
+Description=minions VM daemon + SSH gateway
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/minions serve \
+    --bind 0.0.0.0:3000 \
+    --ssh-bind 0.0.0.0:22
+Environment=MINIONS_API_KEY=your-secret-api-key
+Environment=MINIONS_SSH_PUBKEY_PATH=/root/.ssh/authorized_keys
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart minions
+sudo systemctl status minions
+```
+
+---
+
+## 3. Build & Deploy
+
+```bash
+cd /tmp/minions
+git pull origin main
+
+# Cross-compile for the minipc (x86-64 Linux)
+cargo build --release --target x86_64-unknown-linux-musl
+
+# Copy to host
+scp target/x86_64-unknown-linux-musl/release/minions root@<host>:/usr/local/bin/minions
+
+# Restart daemon
+ssh root@<host> systemctl restart minions
+```
+
+---
+
+## 4. Usage
+
+### Register (first time)
+
+Connect interactively — the gateway prompts for your email:
+
+```bash
+ssh minions@ssh.miniclankers.com
+# Welcome to MINICLANKERS.COM
+#
+# Enter your email to register: you@example.com
+# ✓ Registered! Welcome, you@example.com.
+# Type 'help' for available commands.
+# $
+```
+
+### Manage VMs
+
+```bash
+# List VMs
+ssh minions@ssh.miniclankers.com ls
+
+# Create a VM (auto-named)
+ssh minions@ssh.miniclankers.com new
+
+# Create with specific name / resources
+ssh minions@ssh.miniclankers.com new myapp --cpus 4 --mem 2048
+
+# Destroy a VM
+ssh minions@ssh.miniclankers.com rm myapp
+
+# Restart
+ssh minions@ssh.miniclankers.com restart myapp
+
+# Copy
+ssh minions@ssh.miniclankers.com cp myapp myapp-staging
+
+# Rename (VM must be stopped)
+ssh minions@ssh.miniclankers.com rename myapp production
+
+# Who am I?
+ssh minions@ssh.miniclankers.com whoami
+```
+
+### SSH into a VM
+
+```bash
+# Proxy mode: username = VM name
+ssh myapp@ssh.miniclankers.com
+
+# Run a single command
+ssh myapp@ssh.miniclankers.com cat /etc/os-release
+```
+
+> The gateway authenticates to the VM using its **proxy key**
+> (`/var/lib/minions/proxy_key`), which is automatically injected into every
+> VM's `/root/.ssh/authorized_keys` at creation time.
+
+### SSH config (optional, for convenience)
+
+Add to `~/.ssh/config`:
+
+```
+Host ssh.miniclankers.com
+    User minions
+    IdentityFile ~/.ssh/id_ed25519
+
+# Shortcut: ssh vm-myapp → ssh myapp@ssh.miniclankers.com
+Host vm-*
+    HostName ssh.miniclankers.com
+    User %h
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+Then: `ssh vm-myapp` → proxied into VM `myapp`.
+
+---
+
+## 5. Architecture Notes
+
+### Key injection flow
+
+```
+minions serve --ssh-bind 0.0.0.0:22
+  │
+  ├── Generate /var/lib/minions/proxy_key (if not exists)
+  ├── Generate /var/lib/minions/proxy_key.pub
+  │
+  └── On VM create / copy:
+        └── inject proxy_key.pub → VM /root/.ssh/authorized_keys (append)
+```
+
+### SSH routing
+
+```
+ssh minions@ssh.miniclankers.com ls
+│
+├── DNS: ssh.miniclankers.com → host IP
+├── TCP connect to port 22
+├── Authenticate by SSH public key
+│   └── Look up fingerprint in users/ssh_keys DB table
+│       ├── Found → authenticated user
+│       └── Not found → registration prompt (collect email)
+└── exec_request "ls"
+    └── Call GET /api/vms (local HTTP API)
+        └── Format + return output
+
+ssh myapp@ssh.miniclankers.com
+│
+├── DNS: ssh.miniclankers.com → host IP (same)
+├── TCP connect to port 22
+├── Authenticate by SSH public key (same)
+│   └── ssh_username = "myapp" ≠ "minions" → proxy mode
+└── shell_request
+    └── ConnectedVm::connect("10.0.0.x:22", proxy_key)
+        └── authenticate as root with proxy_key
+            └── Bidirectional channel bridge (tokio split stream)
+```
+
+### DB tables (new in phase 6)
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id          TEXT PRIMARY KEY,   -- UUID v4
+    email       TEXT UNIQUE NOT NULL,
+    created_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ssh_keys (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    public_key  TEXT NOT NULL,       -- openssh format
+    fingerprint TEXT UNIQUE NOT NULL, -- SHA256 base64 (no padding)
+    name        TEXT NOT NULL DEFAULT 'default',
+    created_at  TEXT NOT NULL
+);
+```
+
+Migration runs automatically on gateway startup — no manual DB changes needed.
+
+---
+
+## 6. Troubleshooting
+
+### "proxy key rejected by VM"
+
+The proxy key wasn't injected into this VM (it was created before phase 6).
+Recreate the VM:
+
+```bash
+ssh minions@ssh.miniclankers.com rm oldvm
+ssh minions@ssh.miniclankers.com new oldvm
+```
+
+Or inject manually via VSOCK agent:
+
+```bash
+cat /var/lib/minions/proxy_key.pub
+sudo minions exec oldvm -- bash -c "echo '<key>' >> /root/.ssh/authorized_keys"
+```
+
+### "VM 'xyz' is stopped"
+
+Start the VM first:
+
+```bash
+# Can't start from SSH yet (phase 7) — use HTTP API or CLI
+minions --host http://localhost:3000 create xyz
+```
+
+### Host key changed warning
+
+If you regenerate the host key (e.g., `/var/lib/minions/ssh_host_key`), clients
+will see a "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED" message.
+Remove the old entry:
+
+```bash
+ssh-keygen -R ssh.miniclankers.com
+```


### PR DESCRIPTION
## Phase 6: SSH Gateway

Implements the SSH gateway described in issue #8, phase 6.

### New: `minions-ssh` crate

A standalone library with four modules:

| Module | Role |
|--------|------|
| `db.rs` | `users` + `ssh_keys` tables in the shared SQLite DB |
| `commands.rs` | Command mode: API client that proxies to the local HTTP API |
| `proxy.rs` | Proxy mode: russh client → VM sshd via bidirectional `ChannelStream` |
| `server.rs` | russh `Handler` + `Server`: auth, registration flow, routing |

### Routing (single port, username-based)

```
ssh minions@ssh.miniclankers.com ls       # command mode
ssh minions@ssh.miniclankers.com new myvm # command mode
ssh myvm@ssh.miniclankers.com             # proxy mode (username = VM name)
```

### Registration flow

First-time users (unknown SSH key) are prompted for an email address.
After registration the intended mode (command or proxy) proceeds normally.

### Proxy key injection

On first `minions serve --ssh-bind` run two ED25519 keys are generated via `ssh-keygen`:
- `/var/lib/minions/ssh_host_key` — identifies the gateway to clients
- `/var/lib/minions/proxy_key[.pub]` — used by gateway to `ssh root@vm_ip`

Every `vm::create()` and `vm::copy()` now calls `inject_proxy_key()` (via VSOCK agent)
to append the proxy pubkey to the VM's `/root/.ssh/authorized_keys`.

### Changes to `minions` crate

- `Cargo.toml`: adds `minions-ssh` dependency
- `server.rs`: starts SSH gateway via `tokio::spawn` alongside HTTP API
- `main.rs`: adds `--ssh-bind <addr>` to `serve` subcommand
- `vm.rs`: `inject_proxy_key()` called at end of create + copy

### DNS setup (Cloudflare)

Add in Cloudflare dashboard (DNS only — no proxy):
- `A ssh.miniclankers.com → <host IP>`
- `A miniclankers.com → <host IP>`

See `docs/phase-6-setup.md` for full setup instructions.

---

Closes phase 6 of #8