### PR TITLE
feat: phase 7 — HTTP reverse proxy for VM web services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +572,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1376,6 +1419,7 @@ dependencies = [
  "clap",
  "libc",
  "minions-proto",
+ "minions-proxy",
  "minions-ssh",
  "nix",
  "reqwest",
@@ -1423,6 +1467,27 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "minions-proxy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-extra",
+ "chrono",
+ "http",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1512,6 +1577,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1772,6 +1843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2054,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1996,12 +2074,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2668,6 +2748,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3214,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/minions-host",
     "crates/minions",
     "crates/minions-ssh",
+    "crates/minions-proxy",
 ]
 
 [workspace.dependencies]

--- a/crates/minions-proxy/Cargo.toml
+++ b/crates/minions-proxy/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "minions-proxy"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "minions_proxy"
+path = "src/lib.rs"
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+axum = "0.8"
+axum-extra = { version = "0.10", features = ["cookie"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
+uuid = { version = "1", features = ["v4"] }
+chrono = "0.4"
+http = "1"
+serde_urlencoded = "0.7"

--- a/crates/minions-proxy/src/auth.rs
+++ b/crates/minions-proxy/src/auth.rs
@@ -1,0 +1,157 @@
+//! Simple session-cookie auth for private VMs.
+//!
+//! The password is the value of `MINIONS_API_KEY` (same secret used by the
+//! HTTP API). If no API key is set the proxy accepts all requests.
+//!
+//! Session tokens are stored in memory; they expire after 24 hours or when
+//! the daemon restarts.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::Response;
+use uuid::Uuid;
+
+pub const COOKIE_NAME: &str = "minions_session";
+const SESSION_TTL: Duration = Duration::from_secs(24 * 3600);
+
+// ── Session store ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Default)]
+pub struct Sessions(Arc<Mutex<HashMap<String, Instant>>>);
+
+impl Sessions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check whether a token is valid (exists and not expired).
+    pub fn is_valid(&self, token: &str) -> bool {
+        let mut map = self.0.lock().unwrap();
+        match map.get(token) {
+            Some(&created) if created.elapsed() < SESSION_TTL => true,
+            Some(_) => {
+                map.remove(token); // expired
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// Issue a new session token.
+    pub fn create(&self) -> String {
+        let token = Uuid::new_v4().to_string();
+        self.0.lock().unwrap().insert(token.clone(), Instant::now());
+        token
+    }
+
+    /// Invalidate a token (logout).
+    pub fn revoke(&self, token: &str) {
+        self.0.lock().unwrap().remove(token);
+    }
+}
+
+// ── Cookie helpers ────────────────────────────────────────────────────────────
+
+/// Extract the session token from the Cookie header.
+pub fn extract_token(headers: &HeaderMap) -> Option<String> {
+    let cookie_hdr = headers.get(header::COOKIE)?.to_str().ok()?;
+    cookie_hdr
+        .split(';')
+        .filter_map(|part| {
+            let part = part.trim();
+            let (k, v) = part.split_once('=')?;
+            if k.trim() == COOKIE_NAME { Some(v.trim().to_string()) } else { None }
+        })
+        .next()
+}
+
+/// Build a `Set-Cookie` header value that sets the session cookie.
+pub fn set_cookie(token: &str) -> String {
+    format!("{COOKIE_NAME}={token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400")
+}
+
+/// Build a `Set-Cookie` header value that clears the session cookie.
+pub fn clear_cookie() -> String {
+    format!("{COOKIE_NAME}=; Path=/; HttpOnly; Max-Age=0")
+}
+
+// ── Login / logout pages ──────────────────────────────────────────────────────
+
+/// Redirect the browser to the login page, preserving the original path.
+pub fn redirect_to_login(original_path: &str) -> Response {
+    let location = format!("/__minions/login?next={}", urlencode(original_path));
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, location)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// Render the login HTML form.
+pub fn login_page(next: &str, error: bool) -> Response {
+    let error_msg = if error {
+        r#"<p class="err">Wrong password — try again.</p>"#
+    } else {
+        ""
+    };
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>MINICLANKERS — Login</title>
+  <style>
+    *{{box-sizing:border-box;margin:0;padding:0}}
+    body{{font-family:system-ui,sans-serif;background:#0f1117;color:#e2e8f0;
+          display:flex;align-items:center;justify-content:center;min-height:100vh}}
+    .card{{background:#1a1f2e;border:1px solid #2d3748;border-radius:12px;
+           padding:2rem;width:100%;max-width:360px}}
+    h1{{font-size:1.25rem;font-weight:600;margin-bottom:1.5rem;color:#f7fafc}}
+    label{{display:block;font-size:.875rem;color:#a0aec0;margin-bottom:.4rem}}
+    input{{width:100%;padding:.6rem .75rem;border:1px solid #4a5568;border-radius:6px;
+           background:#2d3748;color:#f7fafc;font-size:1rem}}
+    input:focus{{outline:2px solid #4299e1;border-color:#4299e1}}
+    button{{margin-top:1rem;width:100%;padding:.65rem;border:none;border-radius:6px;
+            background:#4299e1;color:#fff;font-size:1rem;cursor:pointer;font-weight:500}}
+    button:hover{{background:#3182ce}}
+    .err{{color:#fc8181;font-size:.875rem;margin-bottom:1rem}}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>🔒 MINICLANKERS</h1>
+    {error_msg}
+    <form method="POST" action="/__minions/login">
+      <input type="hidden" name="next" value="{next}">
+      <label for="pw">Password</label>
+      <input type="password" id="pw" name="password" autofocus autocomplete="current-password">
+      <button type="submit">Sign in</button>
+    </form>
+  </div>
+</body>
+</html>"#
+    );
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Body::from(html))
+        .unwrap()
+}
+
+/// Minimal URL encoder (just enough for the `next` query param).
+fn urlencode(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/') {
+                vec![c]
+            } else {
+                format!("%{:02X}", c as u32).chars().collect()
+            }
+        })
+        .collect()
+}

--- a/crates/minions-proxy/src/db.rs
+++ b/crates/minions-proxy/src/db.rs
@@ -1,0 +1,90 @@
+//! DB helpers for the HTTPS proxy — VM lookup with proxy fields.
+//!
+//! Runs the migration that adds `proxy_port` and `proxy_public` to the `vms`
+//! table (safe to run multiple times; SQLite ignores duplicate column errors).
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+
+#[derive(Debug, Clone)]
+pub struct VmProxy {
+    pub name: String,
+    pub status: String,
+    pub ip: String,
+    /// Port the VM's web service listens on (default 80).
+    pub proxy_port: u16,
+    /// Whether the VM is publicly accessible without auth.
+    pub proxy_public: bool,
+}
+
+// ── Migration ─────────────────────────────────────────────────────────────────
+
+/// Add proxy columns to `vms` if they don't exist yet.
+pub fn migrate(conn: &Connection) -> Result<()> {
+    // SQLite returns an error if you ADD a column that already exists.
+    // We ignore those errors so this is safe to run repeatedly.
+    let _ = conn.execute_batch(
+        "ALTER TABLE vms ADD COLUMN proxy_port   INTEGER NOT NULL DEFAULT 80;",
+    );
+    let _ = conn.execute_batch(
+        "ALTER TABLE vms ADD COLUMN proxy_public  INTEGER NOT NULL DEFAULT 0;",
+    );
+    Ok(())
+}
+
+// ── Open ──────────────────────────────────────────────────────────────────────
+
+pub fn open(path: &str) -> Result<Connection> {
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let conn = Connection::open(path).context("open sqlite db")?;
+    conn.execute_batch("PRAGMA journal_mode=WAL;").context("WAL")?;
+    migrate(&conn)?;
+    Ok(conn)
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────────
+
+/// Look up a VM by subdomain name. Returns `None` if not found or not running.
+pub fn get_vm_proxy(conn: &Connection, name: &str) -> Result<Option<VmProxy>> {
+    let mut stmt = conn.prepare(
+        "SELECT name, status, ip, proxy_port, proxy_public
+         FROM vms WHERE name = ?1",
+    )?;
+    let mut rows = stmt.query(params![name])?;
+    match rows.next()? {
+        None => Ok(None),
+        Some(row) => Ok(Some(VmProxy {
+            name: row.get(0)?,
+            status: row.get(1)?,
+            ip: row.get(2)?,
+            proxy_port: {
+                let p: i64 = row.get(3)?;
+                p as u16
+            },
+            proxy_public: {
+                let v: i64 = row.get(4)?;
+                v != 0
+            },
+        })),
+    }
+}
+
+/// Update the proxy port for a VM.
+pub fn set_proxy_port(conn: &Connection, name: &str, port: u16) -> Result<bool> {
+    let changed = conn.execute(
+        "UPDATE vms SET proxy_port = ?1 WHERE name = ?2",
+        params![port as i64, name],
+    )?;
+    Ok(changed > 0)
+}
+
+/// Set a VM to public (no auth required).
+pub fn set_proxy_public(conn: &Connection, name: &str, public: bool) -> Result<bool> {
+    let changed = conn.execute(
+        "UPDATE vms SET proxy_public = ?1 WHERE name = ?2",
+        params![if public { 1i64 } else { 0i64 }, name],
+    )?;
+    Ok(changed > 0)
+}

--- a/crates/minions-proxy/src/lib.rs
+++ b/crates/minions-proxy/src/lib.rs
@@ -1,0 +1,66 @@
+//! `minions-proxy` — HTTP reverse proxy for MINICLANKERS.COM.
+//!
+//! Runs on port 80 (or configurable). Cloudflare sits in front and handles
+//! TLS termination (orange-cloud / proxy mode). Requests arrive here as plain
+//! HTTP with `Host: <vmname>.miniclankers.com`.
+//!
+//! Routing:
+//!   <vmname>.miniclankers.com  →  VM's internal IP:proxy_port
+//!   miniclankers.com           →  apex landing page
+//!   /__minions/login            →  login / logout (for private VMs)
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{Router, routing::any};
+use tracing::info;
+
+pub mod auth;
+pub mod db;
+pub mod proxy;
+
+pub use proxy::AppState;
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct ProxyConfig {
+    /// Path to the shared SQLite DB.
+    pub db_path: String,
+    /// Base domain, e.g. "miniclankers.com".
+    pub domain: String,
+    /// Optional API key — used as the proxy password for private VMs.
+    pub api_key: Option<String>,
+}
+
+// ── Serve ─────────────────────────────────────────────────────────────────────
+
+pub async fn serve(config: ProxyConfig, bind: &str) -> Result<()> {
+    // Run the DB migration for proxy columns up-front.
+    {
+        let conn = db::open(&config.db_path).context("open db for proxy migration")?;
+        db::migrate(&conn).context("proxy db migration")?;
+    }
+
+    let state = AppState {
+        db_path: Arc::new(config.db_path),
+        domain: Arc::new(config.domain.clone()),
+        api_key: config.api_key.map(Arc::new),
+        sessions: auth::Sessions::new(),
+        http_client: reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("build http client")?,
+    };
+
+    let app = Router::new()
+        .fallback(any(proxy::handle))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .with_context(|| format!("bind proxy to {bind}"))?;
+
+    info!("HTTP proxy listening on http://{bind} (domain: {})", config.domain);
+    axum::serve(listener, app).await.context("proxy serve")
+}

--- a/crates/minions-proxy/src/proxy.rs
+++ b/crates/minions-proxy/src/proxy.rs
@@ -1,0 +1,312 @@
+//! HTTP reverse proxy handler.
+//!
+//! Receives every request from Cloudflare (already TLS-terminated),
+//! extracts the subdomain, looks up the VM, checks auth, and forwards.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderName, HeaderValue, Method, StatusCode, Uri, header};
+use axum::response::Response;
+use tracing::{debug, warn};
+
+use crate::auth::{Sessions, clear_cookie, extract_token, login_page, redirect_to_login, set_cookie};
+use crate::db;
+
+// ── App state ─────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db_path: Arc<String>,
+    /// Base domain, e.g. "miniclankers.com".
+    pub domain: Arc<String>,
+    /// Optional API key used as the proxy password.
+    pub api_key: Option<Arc<String>>,
+    pub sessions: Sessions,
+    pub http_client: reqwest::Client,
+}
+
+// ── Main handler ──────────────────────────────────────────────────────────────
+
+pub async fn handle(State(state): State<AppState>, req: Request) -> Response {
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_lowercase();
+
+    // Strip port suffix from Host if present.
+    let host = host.split(':').next().unwrap_or("");
+
+    // ── Internal /__minions/ routes ───────────────────────────────────────────
+    let path = req.uri().path().to_string();
+    if path.starts_with("/__minions/") {
+        return handle_internal(req, &state).await;
+    }
+
+    // ── Extract subdomain ─────────────────────────────────────────────────────
+    let subdomain = match extract_subdomain(host, &state.domain) {
+        Some(s) => s,
+        None => return error_response(StatusCode::NOT_FOUND, "Not found"),
+    };
+
+    debug!(subdomain, "proxy request");
+
+    // ── VM lookup ─────────────────────────────────────────────────────────────
+    let vm = {
+        let conn = match db::open(&state.db_path) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("db open error: {}", e);
+                return error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error");
+            }
+        };
+        match db::get_vm_proxy(&conn, &subdomain) {
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                return error_response(
+                    StatusCode::NOT_FOUND,
+                    &format!("No VM named '{subdomain}'"),
+                )
+            }
+            Err(e) => {
+                warn!("db query error: {}", e);
+                return error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error");
+            }
+        }
+    };
+
+    if vm.status != "running" {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!("VM '{subdomain}' is {}", vm.status),
+        );
+    }
+
+    // ── Auth (private VMs) ────────────────────────────────────────────────────
+    if !vm.proxy_public && state.api_key.is_some() {
+        let token = extract_token(req.headers());
+        let valid = token.as_deref().map(|t| state.sessions.is_valid(t)).unwrap_or(false);
+        if !valid {
+            return redirect_to_login(req.uri().path());
+        }
+    }
+
+    // ── Forward request ───────────────────────────────────────────────────────
+    let origin = format!("http://{}:{}", vm.ip, vm.proxy_port);
+    forward(req, &origin, host, &state.http_client).await
+}
+
+// ── Internal routes ───────────────────────────────────────────────────────────
+
+async fn handle_internal(req: Request, state: &AppState) -> Response {
+    let path = req.uri().path();
+    match (req.method().clone(), path) {
+        (Method::GET, "/__minions/login") => {
+            let next = query_param(req.uri(), "next").unwrap_or_else(|| "/".to_string());
+            login_page(&next, false)
+        }
+        (Method::POST, "/__minions/login") => handle_login_post(req, state).await,
+        (Method::GET, "/__minions/logout") => {
+            if let Some(token) = extract_token(req.headers()) {
+                state.sessions.revoke(&token);
+            }
+            Response::builder()
+                .status(StatusCode::FOUND)
+                .header(header::LOCATION, "/")
+                .header(header::SET_COOKIE, clear_cookie())
+                .body(Body::empty())
+                .unwrap()
+        }
+        _ => error_response(StatusCode::NOT_FOUND, "Not found"),
+    }
+}
+
+async fn handle_login_post(req: Request, state: &AppState) -> Response {
+    // Parse form body.
+    let bytes = match axum::body::to_bytes(req.into_body(), 8192).await {
+        Ok(b) => b,
+        Err(_) => return error_response(StatusCode::BAD_REQUEST, "Bad request"),
+    };
+    let form: std::collections::HashMap<String, String> =
+        serde_urlencoded::from_bytes(&bytes).unwrap_or_default();
+
+    let password = form.get("password").map(|s| s.as_str()).unwrap_or("");
+    let next = form.get("next").map(|s| s.as_str()).unwrap_or("/");
+
+    let expected = state.api_key.as_deref().map(|k| k.as_ref()).unwrap_or("");
+    if !expected.is_empty() && password != expected {
+        return login_page(next, true);
+    }
+
+    let token = state.sessions.create();
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, next)
+        .header(header::SET_COOKIE, set_cookie(&token))
+        .body(Body::empty())
+        .unwrap()
+}
+
+// ── Request forwarding ────────────────────────────────────────────────────────
+
+/// Hop-by-hop headers that must not be forwarded.
+static HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+];
+
+async fn forward(req: Request, origin: &str, original_host: &str, client: &reqwest::Client) -> Response {
+    let (parts, body) = req.into_parts();
+
+    // Build the upstream URL.
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    let url = format!("{origin}{path_and_query}");
+
+    // Collect the request body (32 MB limit).
+    let body_bytes = match axum::body::to_bytes(body, 32 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => return error_response(StatusCode::PAYLOAD_TOO_LARGE, "Request body too large"),
+    };
+
+    // Build the upstream request.
+    let mut upstream = client
+        .request(
+            reqwest::Method::from_bytes(parts.method.as_str().as_bytes()).unwrap(),
+            &url,
+        )
+        .body(body_bytes);
+
+    // Copy headers (excluding hop-by-hop).
+    let mut fwd_headers = reqwest::header::HeaderMap::new();
+    for (name, value) in &parts.headers {
+        let n = name.as_str().to_lowercase();
+        if !HOP_BY_HOP.contains(&n.as_str()) {
+            if let (Ok(k), Ok(v)) = (
+                reqwest::header::HeaderName::from_bytes(name.as_str().as_bytes()),
+                reqwest::header::HeaderValue::from_bytes(value.as_bytes()),
+            ) {
+                fwd_headers.insert(k, v);
+            }
+        }
+    }
+
+    // Inject forwarding headers.
+    let _ = fwd_headers.insert(
+        reqwest::header::HeaderName::from_static("x-forwarded-host"),
+        reqwest::header::HeaderValue::from_str(original_host).unwrap_or_else(|_| reqwest::header::HeaderValue::from_static("")),
+    );
+    let _ = fwd_headers.insert(
+        reqwest::header::HeaderName::from_static("x-forwarded-proto"),
+        reqwest::header::HeaderValue::from_static("https"),
+    );
+
+    upstream = upstream.headers(fwd_headers);
+
+    // Send to upstream.
+    let upstream_resp = match upstream.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("upstream error: {}", e);
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                "Could not reach the VM — is the web server running?",
+            );
+        }
+    };
+
+    // Build the downstream response.
+    let status = StatusCode::from_u16(upstream_resp.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    let mut resp = Response::builder().status(status);
+
+    // Copy response headers (excluding hop-by-hop).
+    for (name, value) in upstream_resp.headers() {
+        let n = name.as_str().to_lowercase();
+        if !HOP_BY_HOP.contains(&n.as_str()) {
+            if let (Ok(k), Ok(v)) = (
+                HeaderName::from_bytes(name.as_str().as_bytes()),
+                HeaderValue::from_bytes(value.as_bytes()),
+            ) {
+                resp = resp.header(k, v);
+            }
+        }
+    }
+
+    // Stream the response body back to the client.
+    let body = Body::from_stream(upstream_resp.bytes_stream());
+    resp.body(body).unwrap_or_else(|_| error_response(StatusCode::INTERNAL_SERVER_ERROR, "Response error"))
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Extract the subdomain from `host` given a `base_domain`.
+/// e.g. host="myvm.miniclankers.com", domain="miniclankers.com" → Some("myvm")
+pub fn extract_subdomain<'a>(host: &'a str, domain: &str) -> Option<String> {
+    let suffix = format!(".{}", domain);
+    if host == domain {
+        return None; // apex domain, no subdomain
+    }
+    let sub = host.strip_suffix(&suffix)?;
+    if sub.is_empty() || sub.contains('.') {
+        return None; // nested subdomain or empty
+    }
+    Some(sub.to_string())
+}
+
+fn query_param(uri: &Uri, key: &str) -> Option<String> {
+    uri.query()?
+        .split('&')
+        .find_map(|kv| {
+            let (k, v) = kv.split_once('=')?;
+            if k == key { Some(v.replace('+', " ")) } else { None }
+        })
+}
+
+pub fn error_response(status: StatusCode, message: &str) -> Response {
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{status}</title>
+  <style>
+    body{{font-family:system-ui,sans-serif;background:#0f1117;color:#e2e8f0;
+          display:flex;align-items:center;justify-content:center;height:100vh;margin:0}}
+    .box{{text-align:center}}
+    h1{{font-size:4rem;font-weight:700;color:#fc8181;margin:0}}
+    p{{color:#a0aec0;margin-top:.5rem}}
+    a{{color:#4299e1;text-decoration:none}}
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>{code}</h1>
+    <p>{message}</p>
+    <p><a href="/">← home</a></p>
+  </div>
+</body>
+</html>"#,
+        status = status,
+        code = status.as_u16(),
+        message = message,
+    );
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Body::from(html))
+        .unwrap()
+}

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -10,6 +10,9 @@ path = "src/main.rs"
 [dependencies.minions-ssh]
 path = "../minions-ssh"
 
+[dependencies.minions-proxy]
+path = "../minions-proxy"
+
 [dependencies]
 minions-proto = { path = "../minions-proto" }
 tokio = { workspace = true }

--- a/crates/minions/src/vm.rs
+++ b/crates/minions/src/vm.rs
@@ -59,6 +59,8 @@ pub async fn create(
             rootfs_path: rootfs.to_string_lossy().to_string(),
             created_at: Utc::now().to_rfc3339(),
             stopped_at: None,
+            proxy_port: 80,
+            proxy_public: false,
         };
         db::insert_vm(&conn, &vm_row).context("insert VM into DB").inspect_err(|_| {
             let _ = network::destroy_tap(name);
@@ -412,6 +414,9 @@ pub async fn copy(
             rootfs_path: rootfs.to_string_lossy().to_string(),
             created_at: chrono::Utc::now().to_rfc3339(),
             stopped_at: None,
+            // Inherit proxy settings from source VM.
+            proxy_port: source.proxy_port,
+            proxy_public: source.proxy_public,
         };
         db::insert_vm(&conn, &vm_row).context("insert copied VM into DB").inspect_err(|_| {
             let _ = network::destroy_tap(new_name);

--- a/docs/phase-7-setup.md
+++ b/docs/phase-7-setup.md
@@ -1,0 +1,207 @@
+# Phase 7 — HTTPS Reverse Proxy
+
+Phase 7 adds HTTP proxying for VM web services. Cloudflare handles TLS
+(orange cloud / proxy mode); `minions` runs a plain HTTP proxy on port 80.
+
+```
+Browser → Cloudflare (TLS) → VPS port 80 (minions-proxy) → VM's web server
+```
+
+URLs follow the pattern: `https://<vmname>.miniclankers.com`
+
+---
+
+## 1. VPS / firewall
+
+On a fresh VPS (future deployment), open port 80:
+
+```bash
+ufw allow 80/tcp
+ufw allow 2222/tcp   # SSH gateway
+ufw allow 3000/tcp   # only if you need direct API access; otherwise leave closed
+```
+
+---
+
+## 2. Cloudflare DNS
+
+Add these records (both **proxied** — orange cloud):
+
+| Type | Name | Value |
+|------|------|-------|
+| A | `@` | `<VPS IP>` |
+| A | `*` | `<VPS IP>` |
+
+The wildcard `*` record makes every `<vmname>.miniclankers.com` resolve via
+Cloudflare. Cloudflare's proxy terminates TLS; requests arrive at your VPS as
+plain HTTP with the original `Host` header intact.
+
+> **Note**: Cloudflare's free plan supports wildcard DNS, but wildcard
+> certificates are not included. Since we're not managing TLS ourselves
+> (Cloudflare does it), this is fine.
+
+---
+
+## 3. Systemd service
+
+Update `/etc/systemd/system/minions.service`:
+
+```ini
+[Unit]
+Description=Minions VM Manager Daemon + SSH Gateway + HTTP Proxy
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/minions serve \
+    --ssh-bind 0.0.0.0:2222 \
+    --proxy-bind 0.0.0.0:80 \
+    --domain miniclankers.com
+Environment=MINIONS_API_KEY=<your-secret-key>
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart minions
+```
+
+`MINIONS_API_KEY` is the password for private VMs' login page.
+
+---
+
+## 4. Usage
+
+### Expose a VM's web server
+
+Inside the VM, start a web server:
+
+```bash
+# e.g. a Python HTTP server on port 3000
+python3 -m http.server 3000
+```
+
+Tell minions to proxy that port:
+
+```bash
+ssh -p 2222 minions@ssh.miniclankers.com expose myapp --port 3000
+```
+
+Then visit: `https://myapp.miniclankers.com`
+
+The default port is **80** — if your VM's web server is on 80 you don't need
+to run `expose`.
+
+### Make a VM public (no login required)
+
+By default all VM proxies require a password login. To make one public:
+
+```bash
+ssh -p 2222 minions@ssh.miniclankers.com set-public myapp
+```
+
+To require login again:
+
+```bash
+ssh -p 2222 minions@ssh.miniclankers.com set-private myapp
+```
+
+### `ls` output now shows proxy info
+
+```
+NAME         STATUS     IP               CPUS     MEMORY   PORT  ACCESS
+---------------------------------------------------------------------------
+myapp        running    10.0.0.2            2     1024 MiB  3000  public
+api          running    10.0.0.3            4     2048 MiB    80  private
+```
+
+---
+
+## 5. Private VM auth
+
+Private VMs require login. The login page is at `/__minions/login`.
+
+- **Password**: the value of `MINIONS_API_KEY`
+- **Session**: 24-hour cookie (`minions_session`), in-memory (cleared on restart)
+- **Logout**: visit `/__minions/logout`
+
+---
+
+## 6. Architecture
+
+```
+minions serve --proxy-bind 0.0.0.0:80 --domain miniclankers.com
+│
+├── axum HTTP server on 0.0.0.0:80
+│   ├── /__minions/login   GET  → login HTML page
+│   ├── /__minions/login   POST → validate password, set cookie, redirect
+│   ├── /__minions/logout  GET  → clear cookie, redirect
+│   └── /*                      → proxy handler
+│       ├── Extract subdomain from Host header
+│       ├── Look up VM in DB (get IP + proxy_port + proxy_public)
+│       ├── If stopped → 503
+│       ├── If private + no valid session → redirect to login
+│       └── Forward request to http://{vm.ip}:{vm.proxy_port}
+│
+└── DB columns added to `vms`:
+    proxy_port   INTEGER NOT NULL DEFAULT 80
+    proxy_public INTEGER NOT NULL DEFAULT 0
+```
+
+### New API endpoints
+
+| Method | Path | What it does |
+|--------|------|-------------|
+| `POST` | `/api/vms/{name}/expose` | `{"port": 3000}` — set proxy port |
+| `POST` | `/api/vms/{name}/set-public` | Make VM publicly accessible |
+| `POST` | `/api/vms/{name}/set-private` | Require auth to access |
+
+---
+
+## 7. Request body limit
+
+The proxy currently collects the full request body before forwarding (32 MiB
+limit). This is fine for typical web apps. Large file uploads (> 32 MiB) will
+fail — streaming body forwarding is a Phase 7+ follow-up.
+
+---
+
+## 8. Troubleshooting
+
+### 502 Bad Gateway
+
+The VM's web server isn't running on the configured port. Check:
+
+```bash
+ssh -p 2222 testvm@ssh.miniclankers.com    # log into VM
+ss -tlnp | grep 3000                        # is the server listening?
+```
+
+### 503 Service Unavailable
+
+The VM is stopped. Start it:
+
+```bash
+ssh -p 2222 minions@ssh.miniclankers.com restart testvm
+```
+
+### Login loop
+
+Session cookie is not being set. Check that Cloudflare isn't stripping
+cookies — it shouldn't for the proxy mode. Also verify `MINIONS_API_KEY`
+is set correctly.
+
+### Cloudflare returning "Error 523: Origin unreachable"
+
+Port 80 on the VPS is not listening or is blocked by a firewall. Check:
+
+```bash
+ss -tlnp | grep :80
+ufw status
+```


### PR DESCRIPTION
## Phase 7: HTTPS Reverse Proxy

Cloudflare handles TLS (orange cloud); `minions` runs a plain HTTP proxy on port 80.

```
Browser → Cloudflare (TLS) → VPS port 80 → VM's web server
```

### New crate: `minions-proxy`

| File | What it does |
|------|-------------|
| `db.rs` | `proxy_port` + `proxy_public` columns, idempotent migration |
| `auth.rs` | In-memory session store + login/logout HTML pages |
| `proxy.rs` | Subdomain routing, auth check, request forwarding via reqwest |
| `lib.rs` | `ProxyConfig`, `serve()` |

### New CLI flags on `minions serve`

```
--proxy-bind 0.0.0.0:80
--domain miniclankers.com
```

### New SSH commands

```bash
ssh -p 2222 minions@ssh.miniclankers.com expose myapp --port 3000
ssh -p 2222 minions@ssh.miniclankers.com set-public myapp
ssh -p 2222 minions@ssh.miniclankers.com set-private myapp
```

### New API endpoints

- `POST /api/vms/{name}/expose` — set proxy port
- `POST /api/vms/{name}/set-public`
- `POST /api/vms/{name}/set-private`

### Updated `ls` output

```
NAME         STATUS     IP               CPUS     MEMORY   PORT  ACCESS
myapp        running    10.0.0.2            2     1024 MiB  3000  public
api          running    10.0.0.3            4     2048 MiB    80  private
```

### Deployment (future VPS)

```ini
ExecStart=/usr/local/bin/minions serve \
    --ssh-bind 0.0.0.0:2222 \
    --proxy-bind 0.0.0.0:80 \
    --domain miniclankers.com
```

Closes #8