### PR TITLE
feat: multi-tenancy — VM ownership scoped to SSH gateway users

### DIFF
--- a/crates/minions/src/main.rs
+++ b/crates/minions/src/main.rs
@@ -400,7 +400,7 @@ async fn run_direct(db_path: &str, command: Commands, json: bool) -> Result<()> 
             if ssh_pubkey.is_some() && !json {
                 println!("  (SSH public key found — key-based SSH will work)");
             }
-            let vm = vm::create(db_path, &name, cpus, memory, ssh_pubkey).await?;
+            let vm = vm::create(db_path, &name, cpus, memory, ssh_pubkey, None).await?;
             print_vm(VmJson::from(vm), json);
         }
 
@@ -459,7 +459,7 @@ async fn run_direct(db_path: &str, command: Commands, json: bool) -> Result<()> 
                 println!("Copying VM '{source}' → '{new_name}'…");
             }
             let ssh_pubkey = find_ssh_pubkey();
-            let vm = vm::copy(db_path, &source, &new_name, ssh_pubkey).await?;
+            let vm = vm::copy(db_path, &source, &new_name, ssh_pubkey, None).await?;
             print_vm(VmJson::from(vm), json);
         }
 


### PR DESCRIPTION
Closes #14 (finding #4: no multi-tenancy / authorization in SSH gateway commands)

## Problem

Any registered SSH gateway user could manage **any** VM — list, destroy, exec, rename, SSH into another user's VM. The `user` parameter was passed into every command handler but never used for authorization.

## Design

**Enforcement layer:** the SSH gateway (not the HTTP API).

The HTTP API is already an admin-only channel (requires `MINIONS_API_KEY`). Multi-tenancy is enforced where it matters: the SSH gateway, which is the only multi-user surface.

**Ownership model:** a nullable `owner_id` column on the `vms` table.
- VMs created via the SSH gateway → `owner_id = user.id`
- VMs created via the HTTP API directly → `owner_id = NULL` (admin/system VMs)
- SSH gateway users can only see and touch their own VMs
- NULL-owner VMs are invisible to SSH gateway users (admin-only)

## What changed

### Data layer (`crates/minions/src/db.rs`)

- `Vm` struct gains `owner_id: Option<String>`
- Migration adds `owner_id TEXT` column (nullable; safe to apply on existing DBs via idempotent `ALTER TABLE`)
- New index `idx_vms_owner` for efficient per-owner queries
- New: `list_vms_by_owner(conn, owner_id)`
- New: `get_vm_owned(conn, name, owner_id)` — returns `Err` if wrong owner
- Extracted `VM_COLUMNS` constant so column indices stay in sync across all SELECTs

### VM lifecycle (`crates/minions/src/vm.rs`)

- `create()` and `copy()` accept `owner_id: Option<String>`, stored at insert time
- Direct CLI (admin mode) passes `None`

### HTTP API (`crates/minions/src/api.rs`)

- `CreateRequest` and `CopyRequest` accept optional `owner_id` field
- `VmResponse` exposes `owner_id`
- `GET /api/vms` accepts `?owner_id=` query param — the SSH gateway always passes the authenticated user's ID

### SSH gateway commands (`crates/minions-ssh/src/commands.rs`)

- `VmInfo` gains `owner_id: Option<String>`
- `ApiClient::list_vms(owner_id)` — sends `?owner_id=` filter; users only see their VMs
- `ApiClient::create_vm(…, owner_id)` — stores owner at creation
- `ApiClient::copy_vm(…, owner_id)` — copy is owned by the copying user
- `ApiClient::get_vm(name)` — new single-VM lookup used for ownership checks
- `check_owns(api, name, user)` — central helper that verifies ownership before any mutating operation; uses a vague error message to avoid leaking VM existence to other users
- All 9 mutating commands now call `check_owns()` before proceeding

### SSH proxy (`crates/minions-ssh/src/server.rs`)

- `resolve_vm()` now calls `api.get_vm()` and verifies `owner_id` before opening an SSH proxy connection to a VM

## Access matrix

| Operation | Before | After |
|-----------|--------|-------|
| `ls` | All VMs | Only user's VMs |
| `new` | No owner stored | Owner = authenticated user |
| `rm/stop/restart/rename` | Any VM | Only user's VMs (403 otherwise) |
| `cp` | Any source | Only user's VMs; copy inherits owner |
| `expose/set-public/set-private` | Any VM | Only user's VMs |
| SSH proxy (`vmname@ssh…`) | Any running VM | Only user's running VMs |
| HTTP API (admin key) | All VMs | All VMs (unchanged) |

## Tests (7 new, in-memory SQLite)

| Test | What it verifies |
|------|-----------------|
| `test_insert_and_get_with_owner` | owner_id is persisted and returned |
| `test_insert_and_get_without_owner` | NULL owner round-trips as None |
| `test_list_vms_by_owner_filters_correctly` | per-owner filter excludes other users and admin VMs |
| `test_get_vm_owned_correct_owner` | correct owner gets the VM |
| `test_get_vm_owned_wrong_owner` | mismatched owner returns Err |
| `test_get_vm_owned_admin_vm_rejected` | NULL-owner VM is inaccessible to SSH users |
| `test_get_vm_owned_not_found` | nonexistent VM returns Ok(None) |

All 9 tests pass (`cargo test`).

## Migration safety

The `ALTER TABLE vms ADD COLUMN owner_id TEXT` is idempotent (error ignored). Existing VMs get `owner_id = NULL`, making them admin-only VMs not visible to SSH gateway users — which is the correct default for pre-existing deployments.