### PR TITLE
feat: Phase 8a — VM Snapshots & Backups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -27,6 +27,7 @@ nix = { version = "0.30", features = ["signal"] }
 libc = "0.2"
 subtle = { workspace = true }
 chrono = "0.4"
+uuid = { version = "1", features = ["v4"] }
 tabled = "0.17"
 # HTTP API (daemon)
 axum = "0.8"

--- a/crates/minions/src/hypervisor.rs
+++ b/crates/minions/src/hypervisor.rs
@@ -82,6 +82,28 @@ pub fn spawn(cfg: &VmConfig) -> Result<u32> {
     Ok(child.id())
 }
 
+/// Pause a VM via the CH API (`vm.pause`).
+///
+/// Suspends all vCPUs and I/O threads. The VM remains in memory but stops
+/// executing. Used to quiesce disk state before taking a snapshot.
+/// Call `resume_vm()` to unpause after the snapshot copy completes.
+pub fn pause_vm(api_socket: &str) -> Result<()> {
+    if !std::path::Path::new(api_socket).exists() {
+        anyhow::bail!("CH API socket not found at '{api_socket}' — is the VM running?");
+    }
+    curl_put(api_socket, "vm.pause").context("vm.pause API call failed")?;
+    Ok(())
+}
+
+/// Resume a paused VM via the CH API (`vm.resume`).
+pub fn resume_vm(api_socket: &str) -> Result<()> {
+    if !std::path::Path::new(api_socket).exists() {
+        anyhow::bail!("CH API socket not found at '{api_socket}' — is the VM running?");
+    }
+    curl_put(api_socket, "vm.resume").context("vm.resume API call failed")?;
+    Ok(())
+}
+
 /// Reboot a VM via the CH API (`vm.reboot`).
 ///
 /// Takes the stored `api_socket` path from the DB record so it works correctly

--- a/crates/minions/src/main.rs
+++ b/crates/minions/src/main.rs
@@ -115,11 +115,47 @@ enum Commands {
         #[arg(long)]
         acme_staging: bool,
     },
+    /// Manage VM snapshots
+    Snapshot {
+        #[command(subcommand)]
+        action: SnapshotCommands,
+    },
     /// One-time host setup: bridge, iptables, directories, systemd unit
     Init {
         /// Also persist networking across reboots (sysctl + iptables-persistent)
         #[arg(long)]
         persist: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum SnapshotCommands {
+    /// Create a snapshot of a VM (VM may be running or stopped)
+    Create {
+        /// VM name
+        vm: String,
+        /// Snapshot name (default: UTC timestamp)
+        #[arg(long, short)]
+        name: Option<String>,
+    },
+    /// List snapshots for a VM
+    List {
+        /// VM name
+        vm: String,
+    },
+    /// Restore a VM from a snapshot (VM must be stopped first)
+    Restore {
+        /// VM name
+        vm: String,
+        /// Snapshot name
+        snapshot: String,
+    },
+    /// Delete a snapshot
+    Delete {
+        /// VM name
+        vm: String,
+        /// Snapshot name
+        snapshot: String,
     },
 }
 
@@ -219,6 +255,57 @@ fn print_vm(vm: VmJson, json: bool) {
         println!("  PID:    {}", vm.pid.unwrap_or(0));
         println!();
         println!("  SSH:    ssh root@{}", vm.ip);
+    }
+}
+
+// ── Snapshot output helpers ───────────────────────────────────────────────────
+
+#[derive(Tabled)]
+struct SnapshotRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "SIZE")]
+    size: String,
+    #[tabled(rename = "CREATED")]
+    created_at: String,
+}
+
+fn fmt_bytes(bytes: Option<u64>) -> String {
+    match bytes {
+        None => "-".to_string(),
+        Some(b) if b < 1024 * 1024 => format!("{} B", b),
+        Some(b) if b < 1024 * 1024 * 1024 => format!("{:.1} MiB", b as f64 / (1024.0 * 1024.0)),
+        Some(b) => format!("{:.1} GiB", b as f64 / (1024.0 * 1024.0 * 1024.0)),
+    }
+}
+
+fn print_snapshot(snap: &client::SnapshotResponse, json: bool) {
+    if json {
+        println!("{}", serde_json::to_string_pretty(snap).unwrap());
+    } else {
+        println!();
+        println!("✓ Snapshot '{}'", snap.name);
+        println!("  VM:      {}", snap.vm_name);
+        println!("  Size:    {}", fmt_bytes(snap.size_bytes));
+        println!("  Created: {}", snap.created_at);
+        println!();
+    }
+}
+
+fn print_snapshot_list(vm_name: &str, snaps: &[client::SnapshotResponse], json: bool) {
+    if json {
+        println!("{}", serde_json::to_string_pretty(snaps).unwrap());
+    } else {
+        if snaps.is_empty() {
+            println!("No snapshots for VM '{vm_name}'.");
+            return;
+        }
+        let rows: Vec<SnapshotRow> = snaps.iter().map(|s| SnapshotRow {
+            name: s.name.clone(),
+            size: fmt_bytes(s.size_bytes),
+            created_at: s.created_at.clone(),
+        }).collect();
+        println!("{}", Table::new(rows));
     }
 }
 
@@ -397,6 +484,38 @@ async fn run_remote(host: &str, command: Commands, json: bool, api_key: Option<S
             print!("{logs}");
         }
 
+        Commands::Snapshot { action } => {
+            match action {
+                SnapshotCommands::Create { vm, name } => {
+                    if !json { println!("Creating snapshot for VM '{vm}'…"); }
+                    let snap = c.create_snapshot(&vm, name).await?;
+                    print_snapshot(&snap, json);
+                }
+                SnapshotCommands::List { vm } => {
+                    let snaps = c.list_snapshots(&vm).await?;
+                    print_snapshot_list(&vm, &snaps, json);
+                }
+                SnapshotCommands::Restore { vm, snapshot } => {
+                    if !json { println!("Restoring VM '{vm}' from snapshot '{snapshot}'…"); }
+                    c.restore_snapshot(&vm, &snapshot).await?;
+                    if json {
+                        println!("{}", serde_json::json!({ "message": format!("VM '{vm}' restored from '{snapshot}'") }));
+                    } else {
+                        println!("✓ VM '{vm}' restored from snapshot '{snapshot}'");
+                    }
+                }
+                SnapshotCommands::Delete { vm, snapshot } => {
+                    if !json { println!("Deleting snapshot '{snapshot}' for VM '{vm}'…"); }
+                    c.delete_snapshot(&vm, &snapshot).await?;
+                    if json {
+                        println!("{}", serde_json::json!({ "message": format!("Snapshot '{snapshot}' deleted") }));
+                    } else {
+                        println!("✓ Snapshot '{snapshot}' deleted");
+                    }
+                }
+            }
+        }
+
         // Already handled above or unreachable in remote mode.
         _ => unreachable!(),
     }
@@ -529,6 +648,54 @@ async fn run_direct(db_path: &str, command: Commands, json: bool) -> Result<()> 
                 anyhow::bail!("no serial log found at {}", log_path.display());
             }
             print!("{}", std::fs::read_to_string(&log_path)?);
+        }
+
+        Commands::Snapshot { action } => {
+            match action {
+                SnapshotCommands::Create { vm, name } => {
+                    if !json { println!("Creating snapshot for VM '{vm}'…"); }
+                    let snap = vm::snapshot(db_path, &vm, name).await?;
+                    let client_snap = client::SnapshotResponse {
+                        id: snap.id,
+                        vm_name: snap.vm_name,
+                        name: snap.name,
+                        size_bytes: snap.size_bytes,
+                        created_at: snap.created_at,
+                    };
+                    print_snapshot(&client_snap, json);
+                }
+                SnapshotCommands::List { vm } => {
+                    let snaps = vm::list_snapshots(db_path, &vm)?
+                        .into_iter()
+                        .map(|s| client::SnapshotResponse {
+                            id: s.id,
+                            vm_name: s.vm_name,
+                            name: s.name,
+                            size_bytes: s.size_bytes,
+                            created_at: s.created_at,
+                        })
+                        .collect::<Vec<_>>();
+                    print_snapshot_list(&vm, &snaps, json);
+                }
+                SnapshotCommands::Restore { vm, snapshot } => {
+                    if !json { println!("Restoring VM '{vm}' from snapshot '{snapshot}'…"); }
+                    vm::restore_snapshot(db_path, &vm, &snapshot).await?;
+                    if json {
+                        println!("{}", serde_json::json!({ "message": format!("VM '{vm}' restored from '{snapshot}'") }));
+                    } else {
+                        println!("✓ VM '{vm}' restored from snapshot '{snapshot}'");
+                    }
+                }
+                SnapshotCommands::Delete { vm, snapshot } => {
+                    if !json { println!("Deleting snapshot '{snapshot}' for VM '{vm}'…"); }
+                    vm::delete_snapshot(db_path, &vm, &snapshot).await?;
+                    if json {
+                        println!("{}", serde_json::json!({ "message": format!("Snapshot '{snapshot}' deleted") }));
+                    } else {
+                        println!("✓ Snapshot '{snapshot}' deleted");
+                    }
+                }
+            }
         }
 
         _ => unreachable!(),

--- a/crates/minions/src/vm.rs
+++ b/crates/minions/src/vm.rs
@@ -8,6 +8,7 @@ use tracing::info;
 use minions_proto::Request;
 
 use crate::{agent, db, hypervisor, network, storage};
+use uuid::Uuid;
 
 /// Create a fully networked VM.
 ///
@@ -220,8 +221,15 @@ pub async fn destroy(db_path: &str, name: &str) -> Result<()> {
     network::destroy_tap_device(&tap_device).context("destroy TAP")?;
     storage::destroy_rootfs(name).context("destroy rootfs")?;
 
+    // ── Delete all snapshots (files + DB records) ─────────────────────────────
+    // Best-effort: log errors but don't fail the destroy.
+    if let Err(e) = storage::delete_all_snapshot_files(name) {
+        tracing::warn!("failed to delete snapshot files for VM '{}': {:#}", name, e);
+    }
+
     // ── Remove DB record ──────────────────────────────────────────────────────
     let conn = db::open(db_path)?;
+    db::delete_all_snapshots(&conn, name)?;
     db::delete_vm(&conn, name)?;
     Ok(())
 }
@@ -531,6 +539,178 @@ pub fn list(conn: &rusqlite::Connection) -> Result<Vec<db::Vm>> {
         }
     }
     Ok(vms)
+}
+
+// ── Snapshots ─────────────────────────────────────────────────────────────────
+
+/// Maximum number of snapshots per VM. Attempting to create more returns an error.
+pub const MAX_SNAPSHOTS_PER_VM: u32 = 10;
+
+/// Create a disk-only snapshot of a VM.
+///
+/// If the VM is running, it is briefly paused (vCPUs + I/O suspended) while
+/// the rootfs is copied, then resumed. If the VM is stopped, the copy happens
+/// without pausing.
+///
+/// `snap_name` — user-provided name, or a timestamp if None.
+pub async fn snapshot(db_path: &str, vm_name: &str, snap_name: Option<String>) -> Result<db::Snapshot> {
+    // ── Resolve snapshot name ─────────────────────────────────────────────────
+    let snap_name = snap_name.unwrap_or_else(|| {
+        chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string()
+    });
+    validate_snapshot_name(&snap_name)?;
+
+    // ── Look up VM and check limits ───────────────────────────────────────────
+    let (status, api_socket, rootfs_path) = {
+        let conn = db::open(db_path)?;
+        let vm = db::get_vm(&conn, vm_name)?
+            .with_context(|| format!("VM '{vm_name}' not found"))?;
+        if vm.status == "creating" || vm.status == "starting" {
+            anyhow::bail!("VM '{vm_name}' is still starting — wait until it is running or stopped");
+        }
+        if db::get_snapshot(&conn, vm_name, &snap_name)?.is_some() {
+            anyhow::bail!("snapshot '{snap_name}' already exists for VM '{vm_name}'");
+        }
+        let count = db::count_snapshots(&conn, vm_name)?;
+        if count >= MAX_SNAPSHOTS_PER_VM {
+            anyhow::bail!(
+                "snapshot limit reached ({count}/{MAX_SNAPSHOTS_PER_VM}) for VM '{vm_name}'. \
+                 Delete an existing snapshot first."
+            );
+        }
+        (vm.status, vm.ch_api_socket, vm.rootfs_path)
+    };
+
+    // ── Pause running VM, copy rootfs, resume ────────────────────────────────
+    let was_running = status == "running";
+    if was_running {
+        // Flush guest page cache before pausing.
+        let vsock_socket = {
+            let conn = db::open(db_path)?;
+            let vm = db::get_vm(&conn, vm_name)?.unwrap();
+            std::path::PathBuf::from(vm.ch_vsock_socket)
+        };
+        let _ = agent::send_request(
+            &vsock_socket,
+            minions_proto::Request::Exec { command: "sync".to_string(), args: vec![] },
+        )
+        .await;
+
+        hypervisor::pause_vm(&api_socket)
+            .with_context(|| format!("pause VM '{vm_name}' before snapshot"))?;
+        info!("VM '{vm_name}' paused for snapshot");
+    }
+
+    let copy_result = tokio::task::spawn_blocking({
+        let rootfs_path = rootfs_path.clone();
+        let vm_name = vm_name.to_string();
+        let snap_name = snap_name.clone();
+        move || storage::create_snapshot(&rootfs_path, &vm_name, &snap_name)
+    })
+    .await
+    .context("snapshot copy task panicked")?;
+
+    if was_running {
+        // Always resume, even if the copy failed.
+        if let Err(e) = hypervisor::resume_vm(&api_socket) {
+            tracing::error!("failed to resume VM '{vm_name}' after snapshot: {:#}", e);
+        } else {
+            info!("VM '{vm_name}' resumed after snapshot");
+        }
+    }
+
+    let (_snap_path, size_bytes) = copy_result.context("create snapshot files")?;
+
+    // ── Record snapshot in DB ─────────────────────────────────────────────────
+    let snap = db::Snapshot {
+        id: Uuid::new_v4().to_string(),
+        vm_name: vm_name.to_string(),
+        name: snap_name,
+        size_bytes: Some(size_bytes),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let conn = db::open(db_path)?;
+    db::insert_snapshot(&conn, &snap)?;
+    Ok(snap)
+}
+
+/// List all snapshots for a VM.
+pub fn list_snapshots(db_path: &str, vm_name: &str) -> Result<Vec<db::Snapshot>> {
+    let conn = db::open(db_path)?;
+    // Verify VM exists.
+    db::get_vm(&conn, vm_name)?
+        .with_context(|| format!("VM '{vm_name}' not found"))?;
+    db::list_snapshots(&conn, vm_name)
+}
+
+/// Restore a VM from a snapshot.
+///
+/// The VM **must be stopped** before restoring. This overwrites the VM's
+/// current rootfs with the snapshot copy.
+pub async fn restore_snapshot(db_path: &str, vm_name: &str, snap_name: &str) -> Result<()> {
+    // ── Validate state ────────────────────────────────────────────────────────
+    let rootfs_path = {
+        let conn = db::open(db_path)?;
+        let vm = db::get_vm(&conn, vm_name)?
+            .with_context(|| format!("VM '{vm_name}' not found"))?;
+        if vm.status != "stopped" {
+            anyhow::bail!(
+                "VM '{vm_name}' must be stopped before restoring a snapshot (status: {}). \
+                 Run: minions stop {vm_name}",
+                vm.status
+            );
+        }
+        // Verify snapshot exists.
+        db::get_snapshot(&conn, vm_name, snap_name)?
+            .with_context(|| format!("snapshot '{snap_name}' not found for VM '{vm_name}'"))?;
+        vm.rootfs_path
+    };
+
+    // ── Copy snapshot rootfs over VM rootfs ───────────────────────────────────
+    let rootfs = rootfs_path.clone();
+    let vn = vm_name.to_string();
+    let sn = snap_name.to_string();
+    tokio::task::spawn_blocking(move || storage::restore_snapshot(&rootfs, &vn, &sn))
+        .await
+        .context("restore snapshot task panicked")?
+        .context("restore snapshot files")?;
+
+    info!("VM '{vm_name}' restored from snapshot '{snap_name}'");
+    Ok(())
+}
+
+/// Delete a snapshot (files + DB record).
+pub async fn delete_snapshot(db_path: &str, vm_name: &str, snap_name: &str) -> Result<()> {
+    let conn = db::open(db_path)?;
+    db::get_vm(&conn, vm_name)?
+        .with_context(|| format!("VM '{vm_name}' not found"))?;
+    db::get_snapshot(&conn, vm_name, snap_name)?
+        .with_context(|| format!("snapshot '{snap_name}' not found for VM '{vm_name}'"))?;
+
+    // Delete files first, then DB record.
+    let vn = vm_name.to_string();
+    let sn = snap_name.to_string();
+    tokio::task::spawn_blocking(move || storage::delete_snapshot_files(&vn, &sn))
+        .await
+        .context("delete snapshot task panicked")?
+        .context("delete snapshot files")?;
+
+    db::delete_snapshot(&conn, vm_name, snap_name)?;
+    info!("snapshot '{snap_name}' deleted for VM '{vm_name}'");
+    Ok(())
+}
+
+fn validate_snapshot_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("snapshot name cannot be empty");
+    }
+    if name.len() > 64 {
+        anyhow::bail!("snapshot name must be 64 characters or fewer");
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.') {
+        anyhow::bail!("snapshot name must only contain alphanumeric characters, hyphens, underscores, and dots");
+    }
+    Ok(())
 }
 
 fn validate_name(name: &str) -> Result<()> {


### PR DESCRIPTION
Closes part of #21

## What
Implements disk-only VM snapshots (pause → copy → resume) with full CLI, API, and SSH gateway integration.

## How it works
1. **Snapshot creation** — guest is `sync`'d, VM is paused via CH API (`PUT /api/v1/vm.pause`), rootfs is copied with `cp --sparse=always` to `/var/lib/minions/snapshots/{vm}/{name}/rootfs.ext4`, VM is resumed.  Running VMs pause for only as long as the disk copy takes (typically a few seconds).
2. **Restore** — VM must be stopped; snapshot rootfs is copied back over the VM's rootfs.
3. **Cascade delete** — destroying a VM also removes all its snapshot files and DB records.
4. **Limit** — max 10 snapshots per VM (enforced in `vm::snapshot()`).

## Changes
| File | Change |
|------|--------|
| `db.rs` | `snapshots` table migration + CRUD functions |
| `storage.rs` | Snapshot file ops (create/restore/delete) |
| `hypervisor.rs` | `pause_vm()` / `resume_vm()` via CH API |
| `vm.rs` | `snapshot()`, `restore_snapshot()`, `list_snapshots()`, `delete_snapshot()` |
| `api.rs` | 4 new REST endpoints |
| `main.rs` | `minions snapshot {create,list,restore,delete}` subcommands |
| `client.rs` | Remote-mode HTTP client methods + `SnapshotResponse` type |
| `commands.rs` | SSH gateway: `snapshot`, `snapshots`, `restore`, `rm-snapshot` |

## Tests
6 new DB-level tests. All 16 tests pass.