### PR TITLE
fix: enforce VM network isolation (bridge port isolation + iptables DROP)

### DIFF
--- a/crates/minions/src/network.rs
+++ b/crates/minions/src/network.rs
@@ -3,7 +3,16 @@
 use anyhow::{Context, Result};
 use std::process::Command;
 
-/// Create a TAP device, attach it to br0, and bring it up.
+/// Create a TAP device, attach it to br0, bring it up, and enable bridge
+/// port isolation so this VM cannot communicate directly with other VMs.
+///
+/// Bridge port isolation (`bridge link set dev <tap> isolated on`) is a
+/// kernel-level Layer-2 mechanism (available since Linux 4.18 via
+/// `IFLA_BRPORT_ISOLATED`): the bridge will not forward Ethernet frames
+/// between two isolated ports, regardless of iptables rules or whether
+/// `br_netfilter` is loaded.  Traffic from an isolated port can only reach
+/// the bridge itself (the host at `10.0.0.1`), giving full VM-to-VM
+/// isolation with a single sysfs knob.
 pub fn create_tap(name: &str) -> Result<String> {
     let tap = tap_name(name);
 
@@ -12,6 +21,12 @@ pub fn create_tap(name: &str) -> Result<String> {
 
     run("ip", &["link", "set", &tap, "master", "br0"])
         .with_context(|| format!("attach {tap} to br0"))?;
+
+    // Isolate this bridge port so frames cannot be forwarded to any other
+    // isolated port (i.e. any other VM's TAP device).  This is a Layer-2
+    // control that does not depend on iptables or br_netfilter.
+    run("bridge", &["link", "set", "dev", &tap, "isolated", "on"])
+        .with_context(|| format!("set bridge port isolation on {tap}"))?;
 
     run("ip", &["link", "set", &tap, "up"])
         .with_context(|| format!("bring up {tap}"))?;


### PR DESCRIPTION
Fixes #22

## Problem

All VMs share a single  bridge. Without explicit isolation controls, one VM can ARP-discover and communicate directly with any other VM at Layer 2, regardless of iptables rules.

Two existing gaps:
1. **No L2 isolation** — bridge traffic bypasses iptables entirely without 
2. **Docs bug** — `phase-1-setup.md` told users to add `iptables -I FORWARD -i br0 -o br0 -j ACCEPT`, explicitly *allowing* VM-to-VM traffic

## Changes

### `crates/minions/src/network.rs`

`create_tap()` now sets bridge port isolation on every new TAP device immediately after it is attached to `br0`:

```bash
bridge link set dev <tap> isolated on
```

This is a kernel-level Layer-2 mechanism (Linux 4.18+, `IFLA_BRPORT_ISOLATED`): the bridge will not forward Ethernet frames between two isolated ports, independently of iptables. Traffic from an isolated port can still reach the bridge/host (`10.0.0.1`).

### `crates/minions/src/init.rs`

Added a new `load_br_netfilter()` step (called between `enable_ip_forward` and `setup_iptables`):
- Loads `br_netfilter` module — required for iptables to see bridge-internal packets
- Sets `bridge-nf-call-iptables=1`
- With `--persist`: writes `/etc/modules-load.d/minions.conf` and `/etc/sysctl.d/99-minions-bridge.conf`
- Best-effort (logs a warning on failure — L2 isolation still holds)

`setup_iptables()` now adds an explicit DROP rule:

```
iptables -I FORWARD -i br0 -o br0 -j DROP
```

Inserted at position 1 so it overrides any stale permissive rules (e.g. old `br0 -o br0 ACCEPT` from Docker or manual setup). Rule is idempotent (skipped if already present).

### `docs/phase-1-setup.md`

- **Section 6b**: Replace old `br0 -o br0 ACCEPT` with `modprobe br_netfilter` + DROP rule
- **Section 6c**: Add `bridge link set dev tap-test isolated on` after TAP creation; add isolation model explanation
- **Section 10**: Update cleanup to delete the DROP rule instead of the old ACCEPT rule

## Isolation model after this fix

| Path | L2 | L3 |
|------|----|----|
| VM → internet | ✓ via NAT | ✓ |
| VM → host (10.0.0.1) | ✓ bridge port → non-isolated bridge | ✓ |
| VM A → VM B | **Blocked** (bridge port isolation) | **Dropped** (iptables, when br_netfilter loaded) |

The two layers are independent: L2 isolation works without iptables/br_netfilter; the iptables DROP is a backstop for edge cases (e.g. TAP devices created before this fix, or kernels lacking bridge port isolation support).

## Testing

`cargo test` — all 19 tests pass. System-level calls (`bridge`, `iptables`, `modprobe`) cannot be unit-tested without mocking, consistent with the existing codebase.