### PR TITLE
feat: Web dashboard (askama + htmx) + Rust edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +401,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bcrypt-pbkdf"
@@ -1362,6 +1415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1883,7 @@ name = "minions"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
  "axum",
  "chrono",
  "clap",
@@ -3601,6 +3674,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/minions-agent/Cargo.toml
+++ b/crates/minions-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minions-agent"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "minions-agent"

--- a/crates/minions-host/Cargo.toml
+++ b/crates/minions-host/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minions-host"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "minions-host"

--- a/crates/minions-proto/Cargo.toml
+++ b/crates/minions-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minions-proto"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/minions-proxy/Cargo.toml
+++ b/crates/minions-proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minions-proxy"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "minions_proxy"

--- a/crates/minions-proxy/src/auth.rs
+++ b/crates/minions-proxy/src/auth.rs
@@ -62,7 +62,7 @@ impl Sessions {
         if map.len() >= MAX_SESSIONS {
             if let Some(oldest_key) = map
                 .iter()
-                .min_by_key(|(_, &created)| created)
+                .min_by_key(|(_, created)| *created)
                 .map(|(k, _)| k.clone())
             {
                 map.remove(&oldest_key);

--- a/crates/minions-ssh/Cargo.toml
+++ b/crates/minions-ssh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minions-ssh"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "minions_ssh"

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minions"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "minions"
@@ -14,6 +14,7 @@ path = "../minions-ssh"
 path = "../minions-proxy"
 
 [dependencies]
+askama = "0.12"
 minions-proto = { path = "../minions-proto" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/minions/src/auth.rs
+++ b/crates/minions/src/auth.rs
@@ -36,7 +36,7 @@ struct ErrorResponse {
 }
 
 /// Compare two strings in constant time to prevent timing side-channel attacks.
-fn constant_time_eq(a: &str, b: &str) -> bool {
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
     a.as_bytes().ct_eq(b.as_bytes()).into()
 }
 

--- a/crates/minions/src/dashboard.rs
+++ b/crates/minions/src/dashboard.rs
@@ -1,0 +1,498 @@
+//! Web dashboard — server-rendered HTML via askama + htmx.
+//!
+//! Auth: admin API key entered on the login page is validated against
+//! `MINIONS_API_KEY`. On success a session cookie is issued. All other
+//! dashboard routes require a valid session cookie.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use askama::Template;
+use axum::{
+    Form,
+    Router,
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{Html, IntoResponse, Redirect, Response},
+    routing::{delete, get, post},
+};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::{db, metrics::MetricsStore, server::AppState, vm};
+
+// ── Session store ─────────────────────────────────────────────────────────────
+
+const SESSION_COOKIE: &str = "minions_session";
+const SESSION_TTL: Duration = Duration::from_secs(24 * 3600);
+
+#[derive(Clone, Default)]
+pub struct DashboardSessions(Arc<Mutex<HashMap<String, Instant>>>);
+
+impl DashboardSessions {
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    pub fn create(&self) -> String {
+        let token = Uuid::new_v4().to_string();
+        if let Ok(mut m) = self.0.lock() {
+            m.insert(token.clone(), Instant::now());
+        }
+        token
+    }
+
+    pub fn validate(&self, token: &str) -> bool {
+        let Ok(mut m) = self.0.lock() else { return false };
+        if let Some(ts) = m.get(token) {
+            if ts.elapsed() < SESSION_TTL {
+                return true;
+            }
+            m.remove(token);
+        }
+        false
+    }
+
+    pub fn delete(&self, token: &str) {
+        if let Ok(mut m) = self.0.lock() {
+            m.remove(token);
+        }
+    }
+}
+
+// ── Cookie helpers ────────────────────────────────────────────────────────────
+
+fn get_session_token(headers: &HeaderMap) -> Option<String> {
+    let cookie_str = headers.get(header::COOKIE)?.to_str().ok()?;
+    for part in cookie_str.split(';') {
+        let part = part.trim();
+        if let Some(val) = part.strip_prefix(&format!("{SESSION_COOKIE}=")) {
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
+fn set_session_cookie(token: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!(
+        "{SESSION_COOKIE}={token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400"
+    ))
+    .unwrap()
+}
+
+fn clear_session_cookie() -> HeaderValue {
+    HeaderValue::from_str(&format!(
+        "{SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+    ))
+    .unwrap()
+}
+
+/// Check session cookie. Returns the token if valid, else `None`.
+fn check_session(headers: &HeaderMap, sessions: &DashboardSessions) -> Option<String> {
+    let token = get_session_token(headers)?;
+    if sessions.validate(&token) { Some(token) } else { None }
+}
+
+// ── Template helper ───────────────────────────────────────────────────────────
+
+/// Render an askama template into an HTML response.
+fn render<T: Template>(t: T) -> Response {
+    match t.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+struct VmRow {
+    name: String,
+    status: String,
+    ip: String,
+    vcpus: u32,
+    memory_mb: u32,
+    owner: String,
+    cpu_percent: f64,
+    cpu_percent_str: String,
+}
+
+struct SnapRow {
+    name: String,
+    created_at: String,
+    size_mb: u64,
+}
+
+// ── Templates ─────────────────────────────────────────────────────────────────
+
+#[derive(Template)]
+#[template(path = "login.html")]
+struct LoginTemplate {
+    error: String,
+}
+
+#[derive(Template)]
+#[template(path = "dashboard.html")]
+struct DashboardTemplate {
+    vms: Vec<VmRow>,
+}
+
+#[derive(Template)]
+#[template(path = "vms_fragment.html")]
+struct VmsFragmentTemplate {
+    vms: Vec<VmRow>,
+}
+
+#[derive(Template)]
+#[template(path = "vm_detail.html")]
+struct VmDetailTemplate {
+    vm_name: String,
+    vm_status: String,
+    vm_ip: String,
+    vm_vcpus: u32,
+    vm_memory_mb: u32,
+    vm_owner: String,
+    has_metrics: bool,
+    cpu_str: String,
+    load_str: String,
+    mem_used_mb: u64,
+    mem_total_mb: u64,
+    mem_pct_str: String,
+    disk_used_gb: u64,
+    disk_total_gb: u64,
+    net_rx_str: String,
+    net_tx_str: String,
+    snapshots: Vec<SnapRow>,
+}
+
+#[derive(Template)]
+#[template(path = "metrics_fragment.html")]
+struct MetricsFragmentTemplate {
+    vm_name: String,
+    has_metrics: bool,
+    cpu_str: String,
+    load_str: String,
+    mem_used_mb: u64,
+    mem_total_mb: u64,
+    mem_pct_str: String,
+    disk_used_gb: u64,
+    disk_total_gb: u64,
+    net_rx_str: String,
+    net_tx_str: String,
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/dashboard/login", get(login_page).post(login_submit))
+        .route("/dashboard/logout", get(logout))
+        .route("/dashboard", get(dashboard))
+        .route("/dashboard/vms-fragment", get(vms_fragment))
+        .route("/dashboard/vms/{name}", get(vm_detail))
+        .route("/dashboard/vms/{name}/metrics-fragment", get(metrics_fragment_handler))
+        .route("/dashboard/vms/{name}/restart", post(vm_restart))
+        .route("/dashboard/vms/{name}/stop", post(vm_stop))
+        .route("/dashboard/vms/{name}/snapshot", post(vm_snapshot))
+        .route("/dashboard/vms/{name}", delete(vm_destroy))
+        .route(
+            "/dashboard/vms/{name}/snapshots/{snap}/restore",
+            post(vm_restore_snapshot),
+        )
+        .route(
+            "/dashboard/vms/{name}/snapshots/{snap}",
+            delete(vm_delete_snapshot),
+        )
+}
+
+// ── Handlers — Auth ───────────────────────────────────────────────────────────
+
+async fn login_page(headers: HeaderMap, State(state): State<AppState>) -> Response {
+    if check_session(&headers, &state.sessions).is_some() {
+        return Redirect::to("/dashboard").into_response();
+    }
+    render(LoginTemplate { error: String::new() })
+}
+
+#[derive(Deserialize)]
+struct LoginForm {
+    api_key: String,
+}
+
+async fn login_submit(
+    State(state): State<AppState>,
+    Form(form): Form<LoginForm>,
+) -> Response {
+    let expected = std::env::var("MINIONS_API_KEY").unwrap_or_default();
+    if expected.is_empty() || !crate::auth::constant_time_eq(&form.api_key, &expected) {
+        return render(LoginTemplate { error: "Invalid API key.".to_string() });
+    }
+    let token = state.sessions.create();
+    let mut resp = Redirect::to("/dashboard").into_response();
+    resp.headers_mut()
+        .insert(header::SET_COOKIE, set_session_cookie(&token));
+    resp
+}
+
+async fn logout(headers: HeaderMap, State(state): State<AppState>) -> Response {
+    if let Some(token) = get_session_token(&headers) {
+        state.sessions.delete(&token);
+    }
+    let mut resp = Redirect::to("/dashboard/login").into_response();
+    resp.headers_mut()
+        .insert(header::SET_COOKIE, clear_session_cookie());
+    resp
+}
+
+// ── Handlers — Dashboard ──────────────────────────────────────────────────────
+
+async fn dashboard(headers: HeaderMap, State(state): State<AppState>) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return Redirect::to("/dashboard/login").into_response();
+    }
+    let vms = load_vm_rows(&state);
+    render(DashboardTemplate { vms })
+}
+
+async fn vms_fragment(headers: HeaderMap, State(state): State<AppState>) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let vms = load_vm_rows(&state);
+    render(VmsFragmentTemplate { vms })
+}
+
+async fn vm_detail(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return Redirect::to("/dashboard/login").into_response();
+    }
+    let conn = match db::open(&state.db_path) {
+        Ok(c) => c,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let vm = match db::get_vm(&conn, &name) {
+        Ok(Some(v)) => v,
+        Ok(None) => return (StatusCode::NOT_FOUND, "VM not found").into_response(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let snapshots = db::list_snapshots(&conn, &name).unwrap_or_default().into_iter().map(|s| {
+        let size_mb = snapshot_size_mb(&state.db_path, &name, &s.name);
+        SnapRow { name: s.name, created_at: s.created_at, size_mb }
+    }).collect();
+
+    let (has_metrics, mf) = build_metrics_fields(&name, &state.metrics);
+
+    render(VmDetailTemplate {
+        vm_name: name.clone(),
+        vm_status: vm.status.clone(),
+        vm_ip: vm.ip.clone(),
+        vm_vcpus: vm.vcpus,
+        vm_memory_mb: vm.memory_mb,
+        vm_owner: vm.owner_id.as_deref().unwrap_or("system").to_string(),
+        has_metrics,
+        cpu_str: mf.cpu_str,
+        load_str: mf.load_str,
+        mem_used_mb: mf.mem_used_mb,
+        mem_total_mb: mf.mem_total_mb,
+        mem_pct_str: mf.mem_pct_str,
+        disk_used_gb: mf.disk_used_gb,
+        disk_total_gb: mf.disk_total_gb,
+        net_rx_str: mf.net_rx_str,
+        net_tx_str: mf.net_tx_str,
+        snapshots,
+    })
+}
+
+async fn metrics_fragment_handler(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let (has_metrics, mf) = build_metrics_fields(&name, &state.metrics);
+    render(MetricsFragmentTemplate {
+        vm_name: name,
+        has_metrics,
+        cpu_str: mf.cpu_str,
+        load_str: mf.load_str,
+        mem_used_mb: mf.mem_used_mb,
+        mem_total_mb: mf.mem_total_mb,
+        mem_pct_str: mf.mem_pct_str,
+        disk_used_gb: mf.disk_used_gb,
+        disk_total_gb: mf.disk_total_gb,
+        net_rx_str: mf.net_rx_str,
+        net_tx_str: mf.net_tx_str,
+    })
+}
+
+// ── Handlers — VM actions ─────────────────────────────────────────────────────
+
+async fn vm_stop(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let db_path = state.db_path.as_ref().clone();
+    match vm::stop(&db_path, &name).await {
+        Ok(_) => Html("<span class='text-green-400 text-sm'>✓ VM stopped</span>").into_response(),
+        Err(e) => Html(format!("<span class='text-red-400 text-sm'>✗ {e}</span>")).into_response(),
+    }
+}
+
+async fn vm_restart(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let db_path = state.db_path.as_ref().clone();
+    match vm::restart(&db_path, &name).await {
+        Ok(_) => Html("<span class='text-green-400 text-sm'>✓ VM restarted</span>").into_response(),
+        Err(e) => Html(format!("<span class='text-red-400 text-sm'>✗ {e}</span>")).into_response(),
+    }
+}
+
+async fn vm_destroy(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let db_path = state.db_path.as_ref().clone();
+    match vm::destroy(&db_path, &name).await {
+        Ok(()) => Redirect::to("/dashboard").into_response(),
+        Err(e) => Html(format!("<span class='text-red-400 text-sm'>✗ {e}</span>")).into_response(),
+    }
+}
+
+async fn vm_snapshot(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let db_path = state.db_path.as_ref().clone();
+    match vm::snapshot(&db_path, &name, None).await {
+        Ok(snap) => Html(format!(
+            "<span class='text-green-400 text-sm'>✓ Snapshot '{}' created</span>",
+            snap.name
+        )).into_response(),
+        Err(e) => Html(format!("<span class='text-red-400 text-sm'>✗ {e}</span>")).into_response(),
+    }
+}
+
+async fn vm_restore_snapshot(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path((name, snap)): Path<(String, String)>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let db_path = state.db_path.as_ref().clone();
+    match vm::restore_snapshot(&db_path, &name, &snap).await {
+        Ok(()) => Html("<span class='text-green-400 text-sm'>✓ Restored successfully</span>").into_response(),
+        Err(e) => Html(format!("<span class='text-red-400 text-sm'>✗ {e}</span>")).into_response(),
+    }
+}
+
+async fn vm_delete_snapshot(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Path((name, snap)): Path<(String, String)>,
+) -> Response {
+    if check_session(&headers, &state.sessions).is_none() {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let db_path = state.db_path.as_ref().clone();
+    match vm::delete_snapshot(&db_path, &name, &snap).await {
+        Ok(()) => StatusCode::OK.into_response(),
+        Err(e) => Html(format!("<span class='text-red-400 text-sm'>✗ {e}</span>")).into_response(),
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn load_vm_rows(state: &AppState) -> Vec<VmRow> {
+    let conn = match db::open(&state.db_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let vms = db::list_vms(&conn).unwrap_or_default();
+    vms.into_iter().map(|vm| {
+        let metrics = state.metrics.get_vm(&vm.name);
+        let cpu_percent = metrics.as_ref().map(|m| m.cpu_usage_percent).unwrap_or(0.0);
+        let cpu_percent_str = format!("{:.1}", cpu_percent);
+        VmRow {
+            name: vm.name,
+            status: vm.status,
+            ip: vm.ip,
+            vcpus: vm.vcpus,
+            memory_mb: vm.memory_mb,
+            owner: vm.owner_id.as_deref().unwrap_or("system").to_string(),
+            cpu_percent,
+            cpu_percent_str,
+        }
+    }).collect()
+}
+
+struct MetricsFields {
+    cpu_str: String,
+    load_str: String,
+    mem_used_mb: u64,
+    mem_total_mb: u64,
+    mem_pct_str: String,
+    disk_used_gb: u64,
+    disk_total_gb: u64,
+    net_rx_str: String,
+    net_tx_str: String,
+}
+
+fn build_metrics_fields(vm_name: &str, store: &MetricsStore) -> (bool, MetricsFields) {
+    match store.get_vm(vm_name) {
+        None => (false, MetricsFields {
+            cpu_str: "0.0".into(), load_str: "0.00".into(),
+            mem_used_mb: 0, mem_total_mb: 0, mem_pct_str: "0.0".into(),
+            disk_used_gb: 0, disk_total_gb: 0,
+            net_rx_str: "0.00".into(), net_tx_str: "0.00".into(),
+        }),
+        Some(m) => {
+            let mem_pct = if m.memory_total_mb > 0 {
+                m.memory_used_mb as f64 / m.memory_total_mb as f64 * 100.0
+            } else { 0.0 };
+            (true, MetricsFields {
+                cpu_str: format!("{:.1}", m.cpu_usage_percent),
+                load_str: format!("{:.2}", m.load_avg_1m),
+                mem_used_mb: m.memory_used_mb,
+                mem_total_mb: m.memory_total_mb,
+                mem_pct_str: format!("{:.1}", mem_pct),
+                disk_used_gb: m.disk_used_gb,
+                disk_total_gb: m.disk_total_gb,
+                net_rx_str: format!("{:.2}", m.network_rx_bytes as f64 / (1024.0 * 1024.0)),
+                net_tx_str: format!("{:.2}", m.network_tx_bytes as f64 / (1024.0 * 1024.0)),
+            })
+        }
+    }
+}
+
+/// Returns snapshot size in MiB by checking the rootfs file on disk.
+fn snapshot_size_mb(db_path: &str, vm_name: &str, snap_name: &str) -> u64 {
+    use crate::storage;
+    let path = storage::snapshot_rootfs_path(vm_name, snap_name);
+    std::fs::metadata(path).map(|m| m.len() / (1024 * 1024)).unwrap_or(0)
+}

--- a/crates/minions/src/main.rs
+++ b/crates/minions/src/main.rs
@@ -10,6 +10,7 @@ mod agent;
 mod api;
 mod auth;
 mod client;
+mod dashboard;
 mod db;
 mod hypervisor;
 mod init;

--- a/crates/minions/templates/base.html
+++ b/crates/minions/templates/base.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-gray-950">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Minions{% endblock %} — Minions</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: { extend: {} }
+    }
+  </script>
+</head>
+<body class="h-full text-gray-100" hx-boost="true">
+
+{% block nav %}
+<nav class="bg-gray-900 border-b border-gray-800 px-6 py-3 flex items-center justify-between">
+  <a href="/dashboard" class="text-lg font-bold tracking-tight text-white">⚡ Minions</a>
+  <div class="flex items-center gap-4 text-sm text-gray-400">
+    <a href="/dashboard" class="hover:text-white transition">VMs</a>
+    <a href="/dashboard/logout" class="hover:text-red-400 transition">Log out</a>
+  </div>
+</nav>
+{% endblock %}
+
+<main class="max-w-6xl mx-auto px-6 py-8">
+  {% block content %}{% endblock %}
+</main>
+
+</body>
+</html>

--- a/crates/minions/templates/dashboard.html
+++ b/crates/minions/templates/dashboard.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-xl font-bold text-white">Virtual Machines</h1>
+  <span class="text-sm text-gray-500">auto-refresh every 30s</span>
+</div>
+
+{% include "vms_fragment.html" %}
+{% endblock %}

--- a/crates/minions/templates/login.html
+++ b/crates/minions/templates/login.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block nav %}{% endblock %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+<div class="min-h-screen flex items-center justify-center -mt-8">
+  <div class="w-full max-w-sm">
+    <div class="text-center mb-8">
+      <p class="text-4xl mb-2">⚡</p>
+      <h1 class="text-2xl font-bold text-white">Minions Dashboard</h1>
+      <p class="text-gray-400 text-sm mt-1">Enter your API key to continue</p>
+    </div>
+
+    {% if error.is_empty() == false %}
+    <div class="mb-4 rounded-lg bg-red-900/40 border border-red-700 px-4 py-3 text-sm text-red-300">
+      {{ error }}
+    </div>
+    {% endif %}
+
+    <form method="POST" action="/dashboard/login" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-300 mb-1">API Key</label>
+        <input
+          type="password"
+          name="api_key"
+          required
+          autofocus
+          placeholder="••••••••••••••••"
+          class="w-full rounded-lg bg-gray-800 border border-gray-700 px-4 py-2.5
+                 text-white placeholder-gray-500 focus:outline-none focus:ring-2
+                 focus:ring-indigo-500 focus:border-transparent text-sm"
+        />
+      </div>
+      <button
+        type="submit"
+        class="w-full rounded-lg bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700
+               px-4 py-2.5 text-sm font-semibold text-white transition"
+      >
+        Sign in
+      </button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/crates/minions/templates/metrics_fragment.html
+++ b/crates/minions/templates/metrics_fragment.html
@@ -1,0 +1,32 @@
+<div
+  class="grid grid-cols-2 md:grid-cols-4 gap-3"
+  hx-get="/dashboard/vms/{{ vm_name }}/metrics-fragment"
+  hx-trigger="every 30s"
+  hx-swap="outerHTML"
+>
+{% if has_metrics %}
+  <div class="rounded-xl border border-gray-800 bg-gray-900 p-4">
+    <p class="text-xs text-gray-500 uppercase tracking-wide">CPU</p>
+    <p class="text-2xl font-bold text-white mt-1">{{ cpu_str }}%</p>
+    <p class="text-xs text-gray-600 mt-1">load avg {{ load_str }}</p>
+  </div>
+  <div class="rounded-xl border border-gray-800 bg-gray-900 p-4">
+    <p class="text-xs text-gray-500 uppercase tracking-wide">Memory</p>
+    <p class="text-2xl font-bold text-white mt-1">{{ mem_used_mb }} <span class="text-sm font-normal text-gray-400">/ {{ mem_total_mb }} MiB</span></p>
+    <p class="text-xs text-gray-600 mt-1">{{ mem_pct_str }}% used</p>
+  </div>
+  <div class="rounded-xl border border-gray-800 bg-gray-900 p-4">
+    <p class="text-xs text-gray-500 uppercase tracking-wide">Disk</p>
+    <p class="text-2xl font-bold text-white mt-1">{{ disk_used_gb }} <span class="text-sm font-normal text-gray-400">/ {{ disk_total_gb }} GiB</span></p>
+  </div>
+  <div class="rounded-xl border border-gray-800 bg-gray-900 p-4">
+    <p class="text-xs text-gray-500 uppercase tracking-wide">Network</p>
+    <p class="text-sm font-bold text-white mt-1">↓ {{ net_rx_str }} MiB</p>
+    <p class="text-sm font-bold text-white">↑ {{ net_tx_str }} MiB</p>
+  </div>
+{% else %}
+  <div class="col-span-4 rounded-xl border border-gray-800 bg-gray-900 px-6 py-8 text-center text-gray-600 text-sm">
+    No metrics yet — VM may be starting or agent unreachable.
+  </div>
+{% endif %}
+</div>

--- a/crates/minions/templates/vm_detail.html
+++ b/crates/minions/templates/vm_detail.html
@@ -1,0 +1,125 @@
+{% extends "base.html" %}
+
+{% block title %}{{ vm_name }}{% endblock %}
+
+{% block content %}
+<!-- Back + header -->
+<div class="mb-6">
+  <a href="/dashboard" class="text-sm text-gray-500 hover:text-gray-300 transition">← All VMs</a>
+  <div class="flex items-center gap-3 mt-2">
+    <h1 class="text-2xl font-bold font-mono text-white">{{ vm_name }}</h1>
+    {% if vm_status == "running" %}
+      <span class="inline-flex items-center gap-1.5 rounded-full bg-green-900/40 px-2.5 py-1 text-xs font-medium text-green-400 border border-green-800">
+        <span class="h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse"></span>running
+      </span>
+    {% else if vm_status == "stopped" %}
+      <span class="inline-flex items-center rounded-full bg-gray-800 px-2.5 py-1 text-xs font-medium text-gray-400 border border-gray-700">
+        stopped
+      </span>
+    {% else %}
+      <span class="inline-flex items-center rounded-full bg-yellow-900/40 px-2.5 py-1 text-xs font-medium text-yellow-400 border border-yellow-800">
+        {{ vm_status }}
+      </span>
+    {% endif %}
+  </div>
+  <p class="text-sm text-gray-500 mt-1 font-mono">{{ vm_ip }} · {{ vm_vcpus }} vCPUs · {{ vm_memory_mb }} MiB RAM · owned by {{ vm_owner }}</p>
+</div>
+
+<!-- Action buttons -->
+<div class="flex gap-2 mb-8" id="action-result">
+  {% if vm_status == "running" %}
+  <button
+    hx-post="/dashboard/vms/{{ vm_name }}/stop"
+    hx-target="#action-result"
+    hx-swap="innerHTML"
+    hx-confirm="Stop VM {{ vm_name }}?"
+    class="rounded-lg bg-yellow-700 hover:bg-yellow-600 px-4 py-2 text-sm font-medium text-white transition">
+    ■ Stop
+  </button>
+  <button
+    hx-post="/dashboard/vms/{{ vm_name }}/restart"
+    hx-target="#action-result"
+    hx-swap="innerHTML"
+    hx-confirm="Restart VM {{ vm_name }}?"
+    class="rounded-lg bg-blue-700 hover:bg-blue-600 px-4 py-2 text-sm font-medium text-white transition">
+    ↺ Restart
+  </button>
+  <button
+    hx-post="/dashboard/vms/{{ vm_name }}/snapshot"
+    hx-target="#action-result"
+    hx-swap="innerHTML"
+    class="rounded-lg bg-indigo-700 hover:bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition">
+    📸 Snapshot
+  </button>
+  {% endif %}
+  <button
+    hx-delete="/dashboard/vms/{{ vm_name }}"
+    hx-target="body"
+    hx-push-url="/dashboard"
+    hx-confirm="Permanently destroy {{ vm_name }} and all its data?"
+    class="rounded-lg bg-red-900 hover:bg-red-800 px-4 py-2 text-sm font-medium text-red-300 transition ml-auto">
+    🗑 Destroy
+  </button>
+</div>
+
+<!-- Metrics -->
+<section class="mb-8">
+  <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Live Metrics</h2>
+  <div
+    class="grid grid-cols-2 md:grid-cols-4 gap-3"
+    hx-get="/dashboard/vms/{{ vm_name }}/metrics-fragment"
+    hx-trigger="load, every 30s"
+    hx-swap="outerHTML"
+  >
+    {% include "metrics_fragment.html" %}
+  </div>
+</section>
+
+<!-- Snapshots -->
+<section>
+  <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Snapshots</h2>
+  {% if snapshots.is_empty() %}
+    <p class="text-sm text-gray-600">No snapshots yet.</p>
+  {% else %}
+    <div class="overflow-hidden rounded-xl border border-gray-800">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-900 text-gray-400 text-xs uppercase tracking-wide">
+          <tr>
+            <th class="px-4 py-3 text-left">Name</th>
+            <th class="px-4 py-3 text-left">Created</th>
+            <th class="px-4 py-3 text-left">Size</th>
+            <th class="px-4 py-3 text-left"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800 bg-gray-950">
+          {% for snap in snapshots %}
+          <tr class="hover:bg-gray-900 transition">
+            <td class="px-4 py-3 font-mono text-white">{{ snap.name }}</td>
+            <td class="px-4 py-3 text-gray-400">{{ snap.created_at }}</td>
+            <td class="px-4 py-3 text-gray-400">{{ snap.size_mb }} MiB</td>
+            <td class="px-4 py-3 text-right flex gap-2 justify-end">
+              <button
+                hx-post="/dashboard/vms/{{ vm_name }}/snapshots/{{ snap.name }}/restore"
+                hx-confirm="Restore from snapshot {{ snap.name }}? VM will be stopped first."
+                hx-target="#action-result"
+                hx-swap="innerHTML"
+                class="text-xs text-indigo-400 hover:text-indigo-300 transition">
+                Restore
+              </button>
+              <button
+                hx-delete="/dashboard/vms/{{ vm_name }}/snapshots/{{ snap.name }}"
+                hx-confirm="Delete snapshot {{ snap.name }}?"
+                hx-target="closest tr"
+                hx-swap="outerHTML"
+                class="text-xs text-red-400 hover:text-red-300 transition">
+                Delete
+              </button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/crates/minions/templates/vms_fragment.html
+++ b/crates/minions/templates/vms_fragment.html
@@ -1,0 +1,67 @@
+<div
+  id="vm-table"
+  hx-get="/dashboard/vms-fragment"
+  hx-trigger="every 30s"
+  hx-swap="outerHTML"
+>
+{% if vms.is_empty() %}
+  <div class="rounded-xl border border-gray-800 bg-gray-900 px-6 py-12 text-center text-gray-500">
+    No virtual machines yet.
+  </div>
+{% else %}
+  <div class="overflow-hidden rounded-xl border border-gray-800">
+    <table class="w-full text-sm">
+      <thead class="bg-gray-900 text-gray-400 text-xs uppercase tracking-wide">
+        <tr>
+          <th class="px-4 py-3 text-left">Name</th>
+          <th class="px-4 py-3 text-left">Status</th>
+          <th class="px-4 py-3 text-left">Owner</th>
+          <th class="px-4 py-3 text-left">IP</th>
+          <th class="px-4 py-3 text-left">vCPUs</th>
+          <th class="px-4 py-3 text-left">Memory</th>
+          <th class="px-4 py-3 text-left">CPU%</th>
+          <th class="px-4 py-3 text-left"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-800 bg-gray-950">
+        {% for vm in vms %}
+        <tr class="hover:bg-gray-900 transition">
+          <td class="px-4 py-3 font-mono font-medium text-white">{{ vm.name }}</td>
+          <td class="px-4 py-3">
+            {% if vm.status == "running" %}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-green-900/40 px-2.5 py-0.5 text-xs font-medium text-green-400 border border-green-800">
+                <span class="h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse"></span>running
+              </span>
+            {% else if vm.status == "stopped" %}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-800 px-2.5 py-0.5 text-xs font-medium text-gray-400 border border-gray-700">
+                stopped
+              </span>
+            {% else %}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-yellow-900/40 px-2.5 py-0.5 text-xs font-medium text-yellow-400 border border-yellow-800">
+                {{ vm.status }}
+              </span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-3 text-gray-400 font-mono text-xs">{{ vm.owner }}</td>
+          <td class="px-4 py-3 font-mono text-gray-300">{{ vm.ip }}</td>
+          <td class="px-4 py-3 text-gray-300">{{ vm.vcpus }}</td>
+          <td class="px-4 py-3 text-gray-300">{{ vm.memory_mb }} MiB</td>
+          <td class="px-4 py-3 text-gray-300">
+            {% if vm.cpu_percent > 0.0 %}
+              {{ vm.cpu_percent_str }}%
+            {% else %}
+              <span class="text-gray-600">—</span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-3 text-right">
+            <a href="/dashboard/vms/{{ vm.name }}" class="text-indigo-400 hover:text-indigo-300 text-xs transition">
+              Details →
+            </a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}
+</div>


### PR DESCRIPTION
Part of #21

## Web Dashboard

A server-rendered admin dashboard served directly from the `minions` binary. No npm, no build step — HTML templates via [askama](https://github.com/djc/askama), interactivity via [htmx](https://htmx.org) from CDN, styling via [Tailwind CSS](https://tailwindcss.com) Play CDN.

### Pages

| Route | Description |
|---|---|
| `GET /dashboard/login` | API key login form |
| `GET /dashboard` | VM list — status badges, owner, IP, vCPUs, mem, live CPU% |
| `GET /dashboard/vms/{name}` | VM detail — metrics cards, snapshots table, action buttons |
| `GET /` | Redirects to login |

### htmx auto-refresh

- VM list refreshes every **30 seconds** via `hx-get + hx-trigger="every 30s"`  
- Metrics cards on the VM detail page refresh every **30 seconds**
- All VM actions (stop / restart / snapshot / restore / destroy) use htmx — no full page reload

### Auth

Login form accepts `MINIONS_API_KEY`. On success a `minions_session` cookie is set (HttpOnly, SameSite=Lax, 24h TTL). Sessions are stored in-memory (`Arc<Mutex<HashMap>>`), cleared on restart.

### Screenshots (ASCII)



## Rust edition 2024 upgrade

All six crates updated from `edition = "2021"` to `edition = "2024"`.

One pre-existing code change required by the stricter 2024 edition:
- `minions-proxy/src/auth.rs`: `|(_, &created)| created` → `|(_, created)| *created`  
  (explicit dereference inside an implicitly-borrowing pattern is now an error)

## Tests
All 22 tests pass.