### PR TITLE
feat(dashboard): add proxy settings (port, public/private) to VM detail page

### DIFF
--- a/crates/minions/src/server.rs
+++ b/crates/minions/src/server.rs
@@ -22,6 +22,8 @@ pub struct AppState {
     pub metrics: metrics::MetricsStore,
     /// Dashboard session tokens (in-memory, cleared on restart).
     pub sessions: dashboard::DashboardSessions,
+    /// Base domain for the proxy (e.g. "miniclankers.com"), or None if proxy not configured.
+    pub domain: Option<Arc<String>>,
 }
 
 /// Reconcile DB state with reality.
@@ -154,6 +156,7 @@ pub async fn serve(
         cors_origins,
         metrics: metrics_store,
         sessions: dashboard::DashboardSessions::new(),
+        domain: domain.clone().map(Arc::new),
     };
 
     let app = api::router(state.clone())

--- a/crates/minions/templates/vm_detail.html
+++ b/crates/minions/templates/vm_detail.html
@@ -71,6 +71,72 @@
   </button>
 </div>
 
+<!-- Proxy / Networking -->
+<section class="mb-8">
+  <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Proxy / Networking</h2>
+  <div id="proxy-settings" class="rounded-xl border border-gray-800 bg-gray-900 p-5 space-y-4">
+    <!-- Proxy URL (read-only) -->
+    <div>
+      <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">URL</p>
+      <p class="font-mono text-white text-sm">
+        {% if domain == "" %}
+          <span class="text-gray-600">proxy not configured</span>
+        {% else %}
+          <a href="https://{{ vm_name }}.{{ domain }}" target="_blank" 
+             class="text-indigo-400 hover:text-indigo-300 transition">
+            https://{{ vm_name }}.{{ domain }}
+          </a>
+        {% endif %}
+      </p>
+    </div>
+
+    <!-- Port (editable) -->
+    <div class="flex items-end gap-3">
+      <div>
+        <label class="text-xs text-gray-500 uppercase tracking-wide block mb-1">Port</label>
+        <form hx-post="/dashboard/vms/{{ vm_name }}/expose"
+              hx-target="#proxy-result" hx-swap="innerHTML"
+              class="flex items-center gap-2">
+          <input type="number" name="port" value="{{ proxy_port }}" min="1" max="65535"
+                 class="w-24 rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white font-mono
+                        focus:outline-none focus:border-indigo-500"/>
+          <button type="submit"
+                  class="rounded-lg bg-indigo-700 hover:bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition">
+            Update
+          </button>
+        </form>
+      </div>
+    </div>
+
+    <!-- Access mode toggle -->
+    <div class="flex items-center gap-3">
+      <span class="text-xs text-gray-500 uppercase tracking-wide">Access</span>
+      {% if proxy_public %}
+        <span class="inline-flex items-center rounded-full bg-green-900/40 px-2.5 py-0.5 text-xs font-medium text-green-400 border border-green-800">
+          public
+        </span>
+        <button hx-post="/dashboard/vms/{{ vm_name }}/set-private"
+                hx-target="body"
+                class="text-xs text-gray-400 hover:text-white transition">
+          Make private
+        </button>
+      {% else %}
+        <span class="inline-flex items-center rounded-full bg-yellow-900/40 px-2.5 py-0.5 text-xs font-medium text-yellow-400 border border-yellow-800">
+          private
+        </span>
+        <button hx-post="/dashboard/vms/{{ vm_name }}/set-public"
+                hx-target="body"
+                class="text-xs text-gray-400 hover:text-white transition">
+          Make public
+        </button>
+      {% endif %}
+    </div>
+
+    <!-- Result message area -->
+    <div id="proxy-result"></div>
+  </div>
+</section>
+
 <!-- Metrics -->
 <section class="mb-8">
   <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Live Metrics</h2>


### PR DESCRIPTION
## Summary

Adds a "Proxy / Networking" section to the VM detail page in the dashboard, allowing admins to view and configure:
- Proxy URL (read-only link to `https://{vm}.{domain}`)
- Proxy port (editable via inline form)
- Access mode (public/private toggle)

## Changes

### Backend
- **`server.rs`**: Add `domain: Option<Arc<String>>` to `AppState`, populated from `--domain` CLI arg
- **`dashboard.rs`**: 
  - Add `proxy_port`, `proxy_public`, `domain` fields to `VmDetailTemplate`
  - Add 3 new htmx handlers: `vm_expose`, `vm_set_public`, `vm_set_private`
  - Update `vm_detail` handler to pass proxy fields from DB
  - Register routes: `/dashboard/vms/{name}/expose`, `/set-public`, `/set-private`

### Frontend
- **`vm_detail.html`**: Add "Proxy / Networking" section with:
  - Proxy URL display (shows "proxy not configured" if `--domain` not set)
  - Port number input + htmx form → updates via `POST /dashboard/vms/{name}/expose`
  - Public/Private badge + toggle button → redirects to refresh page with new state

## API Reuse
All handlers use existing `db::set_proxy_port()` and `db::set_proxy_public()` functions already used by:
- HTTP API (`POST /api/vms/:name/expose`, `/set-public`, `/set-private`)
- SSH gateway (`expose <vm> --port <n>`, `set-public <vm>`, `set-private <vm>`)

## Testing
```bash
# Start server with domain
cargo run -- serve --domain miniclankers.com

# Open dashboard, create/view a VM
# → New "Proxy / Networking" section appears
# → Change port, toggle public/private → updates instantly
```

## Screenshots
(When domain is set: proxy URL shown as clickable link)
(When domain is empty: shows "proxy not configured")

Closes #28