### PR TITLE
feat: Custom domain management (API + Dashboard + SSH)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "hickory-resolver",
  "libc",
  "minions-proto",
  "minions-proxy",

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -35,3 +35,5 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 # HTTP client (CLI remote mode) — rustls avoids the openssl/pkg-config dependency
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+# DNS resolution for custom domain verification
+hickory-resolver = "0.24"

--- a/crates/minions/src/db.rs
+++ b/crates/minions/src/db.rs
@@ -655,6 +655,99 @@ fn row_to_snapshot(row: &rusqlite::Row<'_>) -> rusqlite::Result<Snapshot> {
     })
 }
 
+// ── Custom Domains ────────────────────────────────────────────────────────────
+
+/// A custom domain record stored in the database.
+#[derive(Debug, Clone)]
+pub struct CustomDomain {
+    pub id: String,
+    pub vm_name: String,
+    pub domain: String,
+    pub verified: bool,
+    pub created_at: String,
+}
+
+/// Add a custom domain for a VM (initially unverified).
+pub fn add_custom_domain(conn: &Connection, vm_name: &str, domain: &str) -> Result<String> {
+    let id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO custom_domains (id, vm_name, domain, verified, created_at)
+         VALUES (?1, ?2, ?3, 0, ?4)",
+        params![id, vm_name, domain, now],
+    )
+    .context("insert custom domain")?;
+    Ok(id)
+}
+
+/// List all custom domains for a VM.
+pub fn list_custom_domains(conn: &Connection, vm_name: &str) -> Result<Vec<CustomDomain>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, vm_name, domain, verified, created_at
+         FROM custom_domains WHERE vm_name = ?1 ORDER BY created_at",
+    )?;
+    let rows = stmt.query_map(params![vm_name], |row| {
+        Ok(CustomDomain {
+            id: row.get(0)?,
+            vm_name: row.get(1)?,
+            domain: row.get(2)?,
+            verified: {
+                let v: i64 = row.get(3)?;
+                v != 0
+            },
+            created_at: row.get(4)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().context("list custom domains")
+}
+
+/// Look up a custom domain by domain name (to check for duplicates).
+pub fn get_custom_domain_by_name(conn: &Connection, domain: &str) -> Result<Option<CustomDomain>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, vm_name, domain, verified, created_at
+         FROM custom_domains WHERE domain = ?1",
+    )?;
+    let mut rows = stmt.query(params![domain])?;
+    match rows.next()? {
+        None => Ok(None),
+        Some(row) => Ok(Some(CustomDomain {
+            id: row.get(0)?,
+            vm_name: row.get(1)?,
+            domain: row.get(2)?,
+            verified: {
+                let v: i64 = row.get(3)?;
+                v != 0
+            },
+            created_at: row.get(4)?,
+        })),
+    }
+}
+
+/// Remove a custom domain.
+pub fn remove_custom_domain(conn: &Connection, vm_name: &str, domain: &str) -> Result<bool> {
+    let changed = conn.execute(
+        "DELETE FROM custom_domains WHERE vm_name = ?1 AND domain = ?2",
+        params![vm_name, domain],
+    )?;
+    Ok(changed > 0)
+}
+
+/// Mark a domain as verified (certificate provisioned successfully).
+pub fn mark_domain_verified(conn: &Connection, domain: &str) -> Result<bool> {
+    let changed = conn.execute(
+        "UPDATE custom_domains SET verified = 1 WHERE domain = ?1",
+        params![domain],
+    )?;
+    Ok(changed > 0)
+}
+
+/// List all verified domains (for cert renewal checks).
+pub fn list_all_verified_domains(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT domain FROM custom_domains WHERE verified = 1")?;
+    let rows = stmt.query_map([], |row| row.get(0))?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().context("list verified domains")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/minions/src/dns.rs
+++ b/crates/minions/src/dns.rs
@@ -1,0 +1,105 @@
+//! DNS verification for custom domains.
+//!
+//! Checks that a custom domain is properly configured (CNAME or A record) before
+//! allowing registration. This prevents domain squatting and ensures the user
+//! actually controls the domain.
+
+use anyhow::Result;
+use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::proto::rr::RecordType;
+use tracing::{debug, warn};
+
+/// Verify that a custom domain points to the expected VM subdomain or host IP.
+///
+/// Checks:
+/// 1. If the domain has a CNAME record pointing to `{vm_name}.{base_domain}`
+/// 2. If the domain has an A record pointing to `public_ip`
+///
+/// Returns Ok(true) if verification passes, Ok(false) if DNS is misconfigured,
+/// Err if DNS resolution fails (network error, timeout, etc).
+pub async fn verify_domain_dns(
+    domain: &str,
+    vm_name: &str,
+    base_domain: &str,
+    public_ip: Option<&str>,
+) -> Result<bool> {
+    let resolver = TokioAsyncResolver::tokio(
+        ResolverConfig::cloudflare(),
+        ResolverOpts::default(),
+    );
+
+    let expected_cname = format!("{}.{}.", vm_name, base_domain); // Trailing dot = FQDN
+
+    // Try CNAME lookup first
+    debug!(domain, expected = %expected_cname, "checking CNAME record");
+    match resolver.lookup(domain, RecordType::CNAME).await {
+        Ok(cname_lookup) => {
+            for record in cname_lookup.record_iter() {
+                if let Some(cname_data) = record.data().and_then(|d| d.as_cname()) {
+                    let target = cname_data.to_string();
+                    debug!(domain, cname = %target, "found CNAME record");
+                    
+                    // CNAME targets may or may not have a trailing dot
+                    if target == expected_cname || target == expected_cname.trim_end_matches('.') {
+                        debug!(domain, "CNAME points to correct VM subdomain");
+                        return Ok(true);
+                    }
+                }
+            }
+            debug!(domain, "CNAME exists but does not point to VM subdomain");
+        }
+        Err(e) => {
+            debug!(domain, error = %e, "CNAME lookup failed (may not have CNAME)");
+        }
+    }
+
+    // Fall back to A record check if public_ip is configured
+    if let Some(ip) = public_ip {
+        debug!(domain, expected_ip = %ip, "checking A record");
+        match resolver.ipv4_lookup(domain).await {
+            Ok(a_lookup) => {
+                for record in a_lookup.iter() {
+                    let resolved_ip = record.to_string();
+                    debug!(domain, a_record = %resolved_ip, "found A record");
+                    
+                    if resolved_ip == ip {
+                        debug!(domain, "A record points to correct host IP");
+                        return Ok(true);
+                    }
+                }
+                debug!(domain, "A record exists but does not point to host IP");
+            }
+            Err(e) => {
+                debug!(domain, error = %e, "A record lookup failed");
+            }
+        }
+    }
+
+    warn!(
+        domain,
+        "DNS verification failed: no matching CNAME or A record found"
+    );
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_verify_cloudflare_dns() {
+        // This test uses real DNS — cloudflare.com definitely has DNS records.
+        // Just checking the function doesn't panic.
+        let result = verify_domain_dns(
+            "cloudflare.com",
+            "test",
+            "example.com",
+            Some("1.1.1.1"),
+        )
+        .await;
+        
+        // Don't assert true/false since DNS can change, just that it runs
+        assert!(result.is_ok());
+    }
+}

--- a/crates/minions/src/main.rs
+++ b/crates/minions/src/main.rs
@@ -12,6 +12,7 @@ mod auth;
 mod client;
 mod dashboard;
 mod db;
+mod dns;
 mod hypervisor;
 mod init;
 mod metrics;

--- a/crates/minions/src/server.rs
+++ b/crates/minions/src/server.rs
@@ -24,6 +24,8 @@ pub struct AppState {
     pub sessions: dashboard::DashboardSessions,
     /// Base domain for the proxy (e.g. "miniclankers.com"), or None if proxy not configured.
     pub domain: Option<Arc<String>>,
+    /// Host public IP address (for DNS verification of custom domains).
+    pub public_ip: Option<Arc<String>>,
 }
 
 /// Reconcile DB state with reality.
@@ -157,6 +159,7 @@ pub async fn serve(
         metrics: metrics_store,
         sessions: dashboard::DashboardSessions::new(),
         domain: domain.clone().map(Arc::new),
+        public_ip: public_ip.clone().map(Arc::new),
     };
 
     let app = api::router(state.clone())

--- a/crates/minions/templates/vm_detail.html
+++ b/crates/minions/templates/vm_detail.html
@@ -137,6 +137,74 @@
   </div>
 </section>
 
+<!-- Custom Domains -->
+<section class="mb-8">
+  <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Custom Domains</h2>
+  <div class="rounded-xl border border-gray-800 bg-gray-900 p-5 space-y-4">
+    <!-- Add domain form -->
+    <form hx-post="/dashboard/vms/{{ vm_name }}/domains"
+          hx-target="body"
+          class="flex items-end gap-3">
+      <div class="flex-1">
+        <label class="text-xs text-gray-500 uppercase tracking-wide block mb-1">Domain Name</label>
+        <input type="text" name="domain" placeholder="www.example.com"
+               class="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white font-mono
+                      focus:outline-none focus:border-indigo-500"
+               required />
+      </div>
+      <button type="submit"
+              class="rounded-lg bg-indigo-700 hover:bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white transition">
+        + Add Domain
+      </button>
+    </form>
+
+    <!-- Domain list -->
+    {% if custom_domains.is_empty() %}
+      <p class="text-sm text-gray-600">No custom domains configured. Add a CNAME record pointing to {{ vm_name }}.{{ domain }} to get started.</p>
+    {% else %}
+      <div class="overflow-hidden rounded-lg border border-gray-800">
+        <table class="w-full text-sm">
+          <thead class="bg-gray-950 text-gray-400 text-xs uppercase tracking-wide">
+            <tr>
+              <th class="px-4 py-2 text-left">Domain</th>
+              <th class="px-4 py-2 text-left">Status</th>
+              <th class="px-4 py-2 text-right"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-800">
+            {% for d in custom_domains %}
+            <tr class="hover:bg-gray-800 transition">
+              <td class="px-4 py-2 font-mono text-white">{{ d.domain }}</td>
+              <td class="px-4 py-2">
+                {% if d.verified %}
+                  <span class="inline-flex items-center rounded-full bg-green-900/40 px-2 py-0.5 text-xs font-medium text-green-400 border border-green-800">
+                    verified
+                  </span>
+                {% else %}
+                  <span class="inline-flex items-center rounded-full bg-yellow-900/40 px-2 py-0.5 text-xs font-medium text-yellow-400 border border-yellow-800">
+                    pending
+                  </span>
+                {% endif %}
+              </td>
+              <td class="px-4 py-2 text-right">
+                <button
+                  hx-delete="/dashboard/vms/{{ vm_name }}/domains/{{ d.domain }}"
+                  hx-confirm="Remove custom domain {{ d.domain }}?"
+                  hx-target="closest tr"
+                  hx-swap="outerHTML"
+                  class="text-xs text-red-400 hover:text-red-300 transition">
+                  Remove
+                </button>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% endif %}
+  </div>
+</section>
+
 <!-- Metrics -->
 <section class="mb-8">
   <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Live Metrics</h2>


### PR DESCRIPTION
## Changes

This PR implements custom domain management as outlined in #30, allowing users to point their own domains (e.g. ) to their VMs.

### What's included

✅ **DNS verification module** () - Validates that CNAME points to  or A record points to host IP  
✅ **DB helpers** - , , ,   
✅ **API endpoints** -  with validation + DNS checks  
✅ **Dashboard UI** - Custom Domains section on VM detail page with add/list/remove via HTMX  
✅ **SSH commands** - `domain add <vm> <domain>`, `domain ls <vm>`, `domain rm <vm> <domain>`  
✅ **Cloudflare optimization** - Domains marked as verified immediately (TLS terminated at Cloudflare edge)

### How it works

1. User adds a CNAME record: `www.example.com → 66d7b9.miniclankers.com`
2. User calls `ssh minions@ssh.miniclankers.com` → `domain add 66d7b9 www.example.com`
3. API verifies DNS (CNAME or A record), adds to DB, marks verified
4. Proxy receives requests for `www.example.com`, looks up VM, forwards traffic

### Testing

- [x] All existing tests pass
- [x] Compiles cleanly (only unused variable warnings)
- [x] DNS validation rejects malformed domains and subdomains of base domain
- [x] Works with Cloudflare proxied setups (no per-domain cert needed at origin)

### Notes

- For non-Cloudflare setups (direct TLS), full ACME implementation (`tls.rs`) needs to be activated for per-domain cert provisioning
- DNS verification uses Cloudflare's public resolver (1.1.1.1) via `hickory-resolver`

Closes #30