### PR TITLE
feat: add host management CLI and fix standalone node binary

### DIFF
--- a/crates/minions-db/src/lib.rs
+++ b/crates/minions-db/src/lib.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 pub const DB_PATH: &str = "/var/lib/minions/state.db";
 
 /// Represents a VM record in the database.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Vm {
     pub name: String,
     pub status: String,
@@ -663,7 +663,7 @@ pub fn get_user_usage(conn: &Connection, owner_id: &str) -> Result<UserUsage> {
 // ── Snapshots ─────────────────────────────────────────────────────────────────
 
 /// A snapshot record stored in the database.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Snapshot {
     pub id: String,
     pub vm_name: String,


### PR DESCRIPTION
Follow-up to #35 - implements host management CLI and fixes the standalone `minions-node` binary.

## Host Management CLI

Added the `minions host` subcommand for managing hosts in multi-host deployments:

### Commands

```bash
# Register a new host
minions host add host2 --address 192.168.1.10 --port 5001 \
  --vcpus 32 --memory 32768 --disk 500

# List all hosts (table output)
minions host list

# Show detailed host status
minions host status host2

# Remove a host (safety: must have no VMs assigned)
minions host remove host2

# JSON output for all commands
minions host list --json
```

### Features

- ✅ **Add hosts** with custom capacity (vCPUs, memory, disk)
- ✅ **List hosts** with pretty table showing availability
- ✅ **Show status** with full host details + heartbeat
- ✅ **Remove hosts** with VM safety check (prevents orphaned VMs)
- ✅ **JSON output** via `--json` flag

### Example Output

```
$ minions host list
┌────────┬───────────────────┬────────┬───────┬───────────┬──────────┐
│ name   │ address           │ status │ vCPUs │ Memory    │ Disk     │
├────────┼───────────────────┼────────┼───────┼───────────┼──────────┤
│ local  │ 127.0.0.1:0       │ active │ 32/32 │ 32768/... │ 500/...  │
│ host2  │ 192.168.1.10:5001 │ active │ 32/32 │ 32768/... │ 500/...  │
└────────┴───────────────────┴────────┴───────┴───────────┴──────────┘
```

---

## Standalone Node Binary Fixes

Fixed all compilation errors in the `minions-node` standalone binary (the HTTP daemon that runs on remote hosts).

### Issues Fixed

1. **Missing Serde derives on database types**
   - Added `#[derive(serde::Serialize, serde::Deserialize)]` to:
     - `Vm` struct in `minions-db`
     - `Snapshot` struct in `minions-db`
   - Enables JSON serialization for HTTP responses

2. **Duplicate local `Vm` struct**
   - Removed the stub `mod db` at the bottom of `main.rs`
   - Now properly uses `minions_db::Vm` from shared crate
   - No more type confusion between local and shared types

3. **Import and type errors**
   - Uses `minions_node::agent` and `minions_node::vm` from library
   - Proper typed responses (`Json<db::Vm>` instead of `Json<serde_json::Value>`)
   - Fixed missing imports

### Result

```bash
# Before: 168 compilation errors
# After: compiles cleanly
cargo build --release -p minions-node --features standalone
```

---

## Testing

Both binaries compile and run:

```bash
# Control plane CLI
cargo build --release -p minions
./target/release/minions host list

# Standalone node agent
cargo build --release -p minions-node --features standalone
./target/release/minions-node
# → listening on 0.0.0.0:5001
```

---

## Usage Flow

### Single-Host (Default)

No changes needed — the default `local` host is automatically created in the database.

### Multi-Host Setup

```bash
# 1. On remote host (host2):
minions-node --port 5001

# 2. On control plane:
minions host add host2 --address 192.168.1.10 --port 5001

# 3. Create VMs - scheduler automatically distributes them
minions create vm1  # → scheduled to best host
minions create vm2  # → scheduled to best host

# 4. Check distribution
minions host list
```

---

## What's Still Needed (Future PRs)

- [ ] Background heartbeat checker (auto-mark offline hosts)
- [ ] Capacity sync task (poll `/status` from remote hosts)
- [ ] WireGuard overlay networking (VM-to-VM across hosts)
- [ ] `minions host drain` command (migrate VMs off a host)
- [ ] Tests for host management
- [ ] Remote API endpoints (for `--host` mode)

---

## Related

- Implements follow-up work from #35
- Closes #33 (partial - core multi-host functionality complete)