### PR TITLE
feat: Automatic ACME HTTP-01 certificate provisioning for custom domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1703,7 +1702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e04488259349908dd13fadaf3a97523b61da296a468c490e112ecc73d28b47"
 dependencies = [
  "async-trait",
- "aws-lc-rs",
  "base64",
  "bytes",
  "http",
@@ -1713,7 +1711,8 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "rcgen 0.14.7",
+ "rcgen",
+ "ring",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2041,7 +2040,6 @@ dependencies = [
  "hickory-resolver",
  "http",
  "instant-acme",
- "rcgen 0.13.2",
  "reqwest",
  "rusqlite",
  "rustls",
@@ -2662,25 +2660,12 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
- "aws-lc-rs",
  "pem",
+ "ring",
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
@@ -2763,7 +2748,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3047,7 +3032,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3806,12 +3791,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4636,12 +4615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs 0.7.1",
- "aws-lc-rs",
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
  "nom",
  "oid-registry 0.8.1",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/crates/minions-db/src/lib.rs
+++ b/crates/minions-db/src/lib.rs
@@ -845,6 +845,14 @@ pub fn list_all_verified_domains(conn: &Connection) -> Result<Vec<String>> {
         .context("list verified domains")
 }
 
+/// List all unverified domains (for cert provisioning).
+pub fn list_unverified_domains(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT domain FROM custom_domains WHERE verified = 0")?;
+    let rows = stmt.query_map([], |row| row.get(0))?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("list unverified domains")
+}
+
 // ── Host management (multi-host support) ──────────────────────────────────────
 
 /// Insert a new host.

--- a/crates/minions-proxy/Cargo.toml
+++ b/crates/minions-proxy/Cargo.toml
@@ -29,8 +29,7 @@ subtle = { workspace = true }
 # TLS and ACME support
 rustls = { version = "0.23", features = ["ring"] }
 tokio-rustls = "0.26"
-instant-acme = "0.8"
-rcgen = "0.13"
+instant-acme = { version = "0.8", default-features = false, features = ["hyper-rustls", "ring", "rcgen"] }
 rustls-pemfile = "2"
 hickory-resolver = "0.24"
 dashmap = "6"

--- a/crates/minions-proxy/src/db.rs
+++ b/crates/minions-proxy/src/db.rs
@@ -199,3 +199,11 @@ pub fn list_all_verified_domains(conn: &Connection) -> Result<Vec<String>> {
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .context("list verified domains")
 }
+
+/// List all unverified domains (for cert provisioning).
+pub fn list_unverified_domains(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT domain FROM custom_domains WHERE verified = 0")?;
+    let rows = stmt.query_map([], |row| row.get(0))?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("list unverified domains")
+}

--- a/crates/minions-proxy/src/lib.rs
+++ b/crates/minions-proxy/src/lib.rs
@@ -23,11 +23,10 @@ use tracing::{info, warn};
 pub mod auth;
 pub mod db;
 pub mod proxy;
-// Full ACME implementation (work in progress)
-// pub mod tls;
-// Simplified TLS with manual cert provisioning (for initial deployment)
+pub mod tls;
+// Simplified TLS with manual cert provisioning (deprecated, kept for reference)
+#[allow(dead_code)]
 pub mod tls_simple;
-pub use tls_simple as tls;
 
 pub use proxy::AppState;
 


### PR DESCRIPTION
## Summary

Implements automatic Let's Encrypt certificate provisioning via ACME HTTP-01 for custom domains. Replaces the stubbed `tls_simple.rs` with a fully functional `tls.rs` that uses the current `instant-acme` 0.8.4 API.

## Changes

### Core Implementation

1. **Updated `instant-acme` dependencies** (`crates/minions-proxy/Cargo.toml`)
   - Enabled `rcgen` + `ring` features for automatic CSR generation
   - Removed standalone `rcgen` dependency (brought in by instant-acme)

2. **Rewrote `tls.rs`** for instant-acme 0.8.4 (`crates/minions-proxy/src/tls.rs`)
   - Migrated from old API (`Account::create()`, manual CSR) to new builder pattern
   - Uses async iterators (`Authorizations`, `ChallengeHandle`) instead of direct Vec access
   - Implements `RetryPolicy` for polling order readiness and certificate availability
   - `provision_http01()` now uses `Order::finalize()` for automatic key pair + CSR generation
   - Background task provisions pending domains every 60s, renews certs every 12h

3. **Switched `lib.rs`** from `tls_simple` to real `tls` module (`crates/minions-proxy/src/lib.rs`)
   - `tls_simple.rs` kept as `#[allow(dead_code)]` for reference

4. **Removed auto-verify shortcut** (`crates/minions/src/api.rs`)
   - Domains now start as `verified: false`
   - The proxy's background ACME task provisions certs and marks them verified

5. **Added DB helpers** (`crates/minions-db/src/lib.rs`, `crates/minions-proxy/src/db.rs`)
   - `list_unverified_domains()` for cert provisioning loop

## Architecture

### Before (Stubbed)
- Custom domains added via API → immediately marked `verified: true`
- No cert provisioning
- SNI resolver fails on first HTTPS request (no cert file exists)

### After (Automatic)
- Custom domains added via API → `verified: false`
- Background task (every 60s) queries unverified domains
- For each: `acme.provision_http01(domain)` via ACME HTTP-01 challenge
- On success: `db::mark_domain_verified()` + `sni_resolver.reload()`
- On failure: logged, will retry next iteration

### Challenge Flow

```
User adds domain → API writes to DB (verified=false)
                       ↓
         Background task (60s interval) queries DB
                       ↓
         ACME order created for domain
                       ↓
         HTTP-01 challenge token inserted into ChallengeMap
                       ↓
         ACME CA requests http://{domain}/.well-known/acme-challenge/{token}
                       ↓
         Port 80 handler serves key_auth from ChallengeMap
                       ↓
         ACME CA validates → Order becomes Ready
                       ↓
         order.finalize() generates CSR + key pair
                       ↓
         order.poll_certificate() retrieves cert
                       ↓
         Cert stored to /var/lib/minions/certs/{domain}/
                       ↓
         DB updated (verified=true) + SNI resolver reloaded
                       ↓
         https://{domain} now works!
```

## Testing

- [x] `cargo check --workspace` passes
- [x] Borrow checker satisfied (challenge handles dropped before polling)
- [x] Debug trait derived for SniResolver + CertStore (required by ResolvesServerCert)
- [ ] Integration test against Let's Encrypt staging (requires deployed VPS)

## Deployment Notes

- Existing domains marked as `verified: true` without actual certs will fail in SNI resolver
  - Workaround: Delete and re-add them, or manually provision certs
- Let's Encrypt rate limits: 50 certs/week per registered domain
  - Failed HTTP-01 challenges don't count toward limits (order never reaches finalization)
- Port 80 must be reachable for HTTP-01 challenges

## Closes

Closes #38