### PR TITLE
feat: simplify build with musl-cross and GitHub Releases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [target.x86_64-unknown-linux-musl]
-linker = ".cargo/zigcc.sh"
+linker = "x86_64-linux-musl-gcc"
+
+[env]
+CC_x86_64_unknown_linux_musl = "x86_64-linux-musl-gcc"
+AR_x86_64_unknown_linux_musl = "x86_64-linux-musl-ar"

--- a/.cargo/zigcc.sh
+++ b/.cargo/zigcc.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Wrapper to use zig cc as linker for cross-compilation
-ZIG=${ZIG:-~/.local/share/mise/installs/zig/0.15.2/zig}
-exec "$ZIG" cc -target x86_64-linux-musl "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+# Minions build and release automation
+# Cross-compiles from macOS (aarch64-apple-darwin) to Linux (x86_64-unknown-linux-musl)
+#
+# Prerequisites:
+#   brew install FiloSottile/musl-cross/musl-cross
+#   rustup target add x86_64-unknown-linux-musl
+#
+# Usage:
+#   make build                    # Build all binaries for Linux
+#   make release                  # Build + create tarball
+#   make publish VERSION=v0.1.0   # Build + create GitHub release
+
+TARGET = x86_64-unknown-linux-musl
+RELEASE_DIR = target/$(TARGET)/release
+VERSION ?= $(shell git describe --tags --always)
+TARBALL = minions-$(VERSION)-$(TARGET).tar.gz
+BINARIES = minions minions-agent minions-node minions-vsock-cli
+
+.PHONY: all build release publish clean check-musl-cross check-version
+
+all: build
+
+# Check if musl-cross is installed
+check-musl-cross:
+	@which x86_64-linux-musl-gcc > /dev/null || \
+		(echo "Error: x86_64-linux-musl-gcc not found. Install musl-cross:" && \
+		 echo "  brew install FiloSottile/musl-cross/musl-cross" && \
+		 exit 1)
+
+# Build all binaries for Linux
+build: check-musl-cross
+	@echo "Building for $(TARGET)..."
+	cargo build --release --target $(TARGET) \
+		-p minions \
+		-p minions-agent \
+		-p minions-node \
+		-p minions-vsock-cli
+	@echo "✓ Build complete. Binaries in $(RELEASE_DIR)/"
+	@ls -lh $(RELEASE_DIR)/minions*
+
+# Create a release tarball
+release: build
+	@echo "Creating release tarball $(TARBALL)..."
+	@mkdir -p dist
+	@rm -f dist/$(TARBALL)
+	@tar -czf dist/$(TARBALL) -C $(RELEASE_DIR) $(BINARIES)
+	@echo "✓ Tarball created: dist/$(TARBALL)"
+	@ls -lh dist/$(TARBALL)
+	@echo ""
+	@echo "Contents:"
+	@tar -tzf dist/$(TARBALL)
+
+# Check that VERSION is set for publish
+check-version:
+	@if [ -z "$(VERSION)" ] || [ "$(VERSION)" = "" ]; then \
+		echo "Error: VERSION not set. Usage: make publish VERSION=v0.1.0"; \
+		exit 1; \
+	fi
+
+# Create a GitHub release with binaries
+publish: check-version release
+	@echo "Publishing GitHub release $(VERSION)..."
+	@if git rev-parse "$(VERSION)" >/dev/null 2>&1; then \
+		echo "Tag $(VERSION) already exists. Skipping tag creation."; \
+	else \
+		echo "Creating tag $(VERSION)..."; \
+		git tag -a "$(VERSION)" -m "Release $(VERSION)"; \
+		git push origin "$(VERSION)"; \
+	fi
+	@echo "Creating GitHub release..."
+	gh release create "$(VERSION)" \
+		dist/$(TARBALL) \
+		--title "Release $(VERSION)" \
+		--notes "Automated release for $(VERSION). See CHANGELOG for details." \
+		--draft=false
+	@echo "✓ Release published: https://github.com/thiagovarela/minions/releases/tag/$(VERSION)"
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	cargo clean
+	rm -rf dist/
+	@echo "✓ Clean complete"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,128 @@
+# Minions
+
+A VM-as-a-Service platform built on Cloud Hypervisor with direct rootfs (no Kata runtime layer). Instant VMs on the internet, accessible over HTTPS and SSH.
+
+## Quick Start
+
+See `docs/` for full setup guides:
+- `docs/phase-1-setup.md` — Provision the host, build kernel + base rootfs
+- `docs/phase-2-setup.md` — Test guest agent via VSOCK
+- `docs/phase-3-setup.md` — Bake agent into base image
+- `docs/phase-4-setup.md` — VM lifecycle (create, list, delete)
+- `docs/phase-5-setup.md` — SSH gateway
+- `docs/phase-6-setup.md` — HTTPS reverse proxy
+- `docs/phase-7-setup.md` — Multi-host architecture
+
+## Build & Release
+
+Minions uses **static Linux binaries** built via cross-compilation from macOS to `x86_64-unknown-linux-musl`. Releases are published to GitHub with pre-built binaries.
+
+### Prerequisites (Development)
+
+**On macOS:**
+```bash
+# Install musl cross-compiler (one-time, ~15 min first run)
+brew install FiloSottile/musl-cross/musl-cross
+
+# Add Rust Linux target
+rustup target add x86_64-unknown-linux-musl
+```
+
+**On Linux server:**
+```bash
+# No Rust toolchain needed — just download pre-built binaries
+curl -sSL https://raw.githubusercontent.com/thiagovarela/minions/main/scripts/install.sh | bash
+```
+
+### Build Locally
+
+```bash
+# Build all binaries for Linux
+make build
+
+# Create a release tarball (dist/minions-<version>-x86_64-unknown-linux-musl.tar.gz)
+make release
+```
+
+### Publish a Release
+
+```bash
+# Build + create GitHub Release with binaries attached
+make publish VERSION=v0.2.0
+```
+
+This will:
+1. Build all binaries (`minions`, `minions-agent`, `minions-node`, `minions-vsock-cli`)
+2. Create a tarball
+3. Create a git tag (if it doesn't exist)
+4. Create a GitHub Release with the tarball attached
+
+### Deploy to Linux Server
+
+**Install binaries:**
+```bash
+# Latest release
+curl -sSL https://raw.githubusercontent.com/thiagovarela/minions/main/scripts/install.sh | bash
+
+# Specific version
+curl -sSL https://raw.githubusercontent.com/thiagovarela/minions/main/scripts/install.sh | bash -s -- v0.2.0
+```
+
+**Bake agent into VM base image:**
+```bash
+# After installing binaries, update the base rootfs image
+sudo /usr/local/bin/minions bake-agent
+
+# Or run the script directly
+sudo ./scripts/bake-agent.sh
+```
+
+This injects `minions-agent` into `/var/lib/minions/images/base-ubuntu.ext4` so all new VMs have the agent pre-installed.
+
+## Development Workflow
+
+```bash
+# 1. Make changes
+git checkout -b feat/my-feature
+
+# 2. Build locally (macOS)
+make build
+
+# 3. Test on Linux server
+scp target/x86_64-unknown-linux-musl/release/minions user@server:/tmp/
+ssh user@server sudo install -m 0755 /tmp/minions /usr/local/bin/minions
+
+# 4. Commit + push
+git commit -am "feat: my awesome feature"
+git push origin feat/my-feature
+
+# 5. Create PR, merge to main
+
+# 6. Publish release
+git checkout main
+git pull
+make publish VERSION=v0.3.0
+```
+
+## Architecture
+
+See `docs/sketch-plan.md` for the full design.
+
+**High-level:**
+- **Guest agent** (`minions-agent`) runs inside each VM, listens on VSOCK for control commands
+- **Host daemon** (`minions`) manages VM lifecycle (create, delete, restart), SSH gateway, HTTPS proxy
+- **Node agent** (`minions-node`) runs on each physical host in multi-host mode
+- **Communication:** VSOCK for host↔guest, HTTP/JSON for CLI↔daemon and daemon↔node
+
+**Storage:**
+- LVM thin provisioning for instant VM creation (copy-on-write snapshots)
+- Each VM has two disks: rootfs (ephemeral, snapshot of base image) + data (persistent)
+
+**Networking:**
+- Bridge (`br0`) with NAT for VM internet access
+- TAP devices per VM, IP allocation from pool (SQLite)
+- Wildcard DNS (`*.yourdomain.xyz`) → HTTPS proxy routes by subdomain
+
+## License
+
+MIT (or whatever you choose)

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
-[tools]
-zig = "0.15.2"
+# No build tools required in mise — use musl-cross from Homebrew
+# Install: brew install FiloSottile/musl-cross/musl-cross

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Minions installer — download and install pre-built Linux binaries from GitHub Releases
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/thiagovarela/minions/main/scripts/install.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/thiagovarela/minions/main/scripts/install.sh | bash -s -- v0.1.0
+#
+# What it does:
+#   1. Validates platform (x86_64 + Linux only)
+#   2. Downloads the tarball from the specified GitHub Release (or latest)
+#   3. Extracts binaries to /usr/local/bin/
+#   4. Verifies installation
+
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+REPO="thiagovarela/minions"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+VERSION="${1:-latest}"
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}[minions]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[minions]${NC} $*"; }
+fail()  { echo -e "${RED}[minions]${NC} $*" >&2; exit 1; }
+ok()    { echo -e "${GREEN}✓${NC} $*"; }
+
+# ── Preconditions ─────────────────────────────────────────────────────────────
+info "Minions installer"
+echo ""
+
+# Check platform
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+
+if [ "$OS" != "Linux" ]; then
+    fail "Unsupported OS: $OS (only Linux is supported)"
+fi
+
+if [ "$ARCH" != "x86_64" ]; then
+    fail "Unsupported architecture: $ARCH (only x86_64 is supported)"
+fi
+
+TARGET="x86_64-unknown-linux-musl"
+ok "Platform: $OS $ARCH (target: $TARGET)"
+
+# Check if running as root
+if [ "$EUID" -eq 0 ]; then
+    SUDO=""
+else
+    if ! command -v sudo >/dev/null 2>&1; then
+        fail "sudo not found. Please run as root or install sudo."
+    fi
+    SUDO="sudo"
+    warn "Not running as root. Will use sudo for installation to $INSTALL_DIR."
+fi
+
+# ── Resolve version ──────────────────────────────────────────────────────────
+if [ "$VERSION" = "latest" ]; then
+    info "Fetching latest release version..."
+    VERSION=$(curl -sSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ -z "$VERSION" ]; then
+        fail "Failed to fetch latest release version from GitHub API"
+    fi
+    ok "Latest version: $VERSION"
+else
+    info "Using specified version: $VERSION"
+fi
+
+TARBALL="minions-${VERSION}-${TARGET}.tar.gz"
+URL="https://github.com/$REPO/releases/download/$VERSION/$TARBALL"
+
+# ── Download ─────────────────────────────────────────────────────────────────
+TMPDIR="$(mktemp -d)"
+trap "rm -rf '$TMPDIR'" EXIT
+
+info "Downloading $TARBALL from GitHub..."
+if ! curl -sSL --fail "$URL" -o "$TMPDIR/$TARBALL"; then
+    fail "Failed to download $URL. Check that the release exists."
+fi
+ok "Downloaded $(du -h "$TMPDIR/$TARBALL" | cut -f1)"
+
+# ── Extract ──────────────────────────────────────────────────────────────────
+info "Extracting binaries..."
+tar -xzf "$TMPDIR/$TARBALL" -C "$TMPDIR"
+ok "Extracted"
+
+# ── Install ──────────────────────────────────────────────────────────────────
+info "Installing to $INSTALL_DIR..."
+BINARIES=(minions minions-agent minions-node minions-vsock-cli)
+
+for bin in "${BINARIES[@]}"; do
+    if [ ! -f "$TMPDIR/$bin" ]; then
+        warn "Binary $bin not found in tarball, skipping"
+        continue
+    fi
+    $SUDO install -m 0755 "$TMPDIR/$bin" "$INSTALL_DIR/$bin"
+    ok "Installed $INSTALL_DIR/$bin"
+done
+
+# ── Verify ───────────────────────────────────────────────────────────────────
+info "Verifying installation..."
+if command -v minions >/dev/null 2>&1; then
+    VERSION_OUTPUT="$(minions --version 2>&1 || echo 'version check failed')"
+    ok "minions installed: $VERSION_OUTPUT"
+else
+    warn "minions not found in PATH. You may need to add $INSTALL_DIR to PATH."
+fi
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────────"
+ok "Installation complete!"
+echo ""
+echo "  Binaries installed to: $INSTALL_DIR"
+echo "  Version: $VERSION"
+echo ""
+echo "  Next steps:"
+echo "    - Run 'minions --help' to get started"
+echo "    - Update the base VM image: sudo bake-agent.sh (if agent changed)"
+echo "────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

Replaces zig-based cross-compilation with **musl-cross GCC toolchain** for building Linux binaries on macOS. This fixes build failures with `aws-lc-sys` and other C dependencies that couldn't handle zig's target triple format.

The new workflow decouples building from deploying:
- **Build on macOS** → `make publish VERSION=v0.2.0` creates a GitHub Release
- **Deploy on Linux** → `curl -sSL .../install.sh | bash` downloads pre-built binaries (no Rust toolchain needed)

Fixes #39

---

## Changes

### 1. Replace zig with musl-cross

**Before (broken):**
- `.cargo/zigcc.sh` wrapper around `zig cc`
- Failed with `duplicate symbol: _start` (zig's musl CRT clashed with Rust's)
- `cc` crate passed `--target=x86_64-unknown-linux-musl` which zig couldn't parse

**After (working):**
- `.cargo/config.toml` → `linker = "x86_64-linux-musl-gcc"`
- `x86_64-linux-musl-gcc` from `brew install FiloSottile/musl-cross/musl-cross`
- Standard GCC cross-compiler, no wrapper needed, works with all C deps

### 2. Add `Makefile` for build automation

Targets:
- `make build` — cross-compile all binaries for Linux
- `make release` — build + create tarball (`dist/minions-<version>-x86_64-unknown-linux-musl.tar.gz`)
- `make publish VERSION=v0.1.0` — build + create GitHub Release with binaries attached

Binaries included in releases:
- `minions` (main CLI/daemon)
- `minions-agent` (guest agent, baked into VM images)
- `minions-node` (node agent, standalone mode)
- `minions-vsock-cli` (debug tool)

### 3. Add `scripts/install.sh` for curl-friendly installation



What it does:
1. Detects platform (validates x86_64 + Linux)
2. Downloads tarball from latest GitHub Release (or specific version via arg)
3. Extracts to `/usr/local/bin/`
4. Verifies installation

### 4. Update `scripts/bake-agent.sh` to use pre-built binaries

**Before:**
- Ran `cargo build --release` on the Linux server
- Required Rust toolchain installed

**After:**
- Expects binaries already installed at `/usr/local/bin/` (via `install.sh`)
- Or accepts `BINARIES_DIR=/path/to/extracted/release` env var
- No Rust toolchain needed on the server

### 5. Add `README.md` with build/release/deploy docs

Documents:
- Prerequisites (musl-cross on macOS, nothing on Linux)
- Build workflow (`make build`, `make release`, `make publish`)
- Deploy workflow (`install.sh` → `bake-agent.sh`)
- Development workflow (build locally, test on server, publish release)

---

## Testing

### On macOS (prerequisites)

```bash
# Install musl-cross (one-time, ~15 min first run)
brew install FiloSottile/musl-cross/musl-cross

# Add Rust target (if not already added)
rustup target add x86_64-unknown-linux-musl
```

### Build test

```bash
# Build all binaries
make build

# Verify
file target/x86_64-unknown-linux-musl/release/minions
# Should show: ELF 64-bit LSB executable, x86-64, statically linked

# Create release tarball
make release

# Check contents
tar -tzf dist/minions-*.tar.gz
```

### Publish test (manual, don't run in CI)

```bash
# Creates tag + GitHub Release (requires gh CLI auth)
make publish VERSION=v0.1.0-test
```

### Linux server test

```bash
# Install from local tarball (before publishing)
scp dist/minions-*.tar.gz user@server:/tmp/
ssh user@server
tar -xzf /tmp/minions-*.tar.gz -C /tmp/
sudo install -m 0755 /tmp/minions* /usr/local/bin/

# Verify
minions --version

# Bake agent into base image
sudo bake-agent.sh
```

---

## Migration Notes

- **No migration needed** — this is additive (adds Makefile, install.sh, README)
- Existing deployments can keep using local builds, or switch to the new flow
- `bake-agent.sh` is backward compatible (works with both local builds and pre-built binaries via `BINARIES_DIR`)

---

## Files Changed

| File | Change |
|------|--------|
| `.cargo/config.toml` | Update linker to `x86_64-linux-musl-gcc`, set CC/AR env |
| `.cargo/zigcc.sh` | **Deleted** |
| `mise.toml` | Remove zig dependency |
| `Makefile` | **New** — build, release, publish targets |
| `scripts/install.sh` | **New** — curl-friendly installer |
| `scripts/bake-agent.sh` | Use pre-built binaries instead of `cargo build` |
| `README.md` | **New** — build/release/deploy docs |

---

## Next Steps After Merge

1. Install musl-cross: `brew install FiloSottile/musl-cross/musl-cross`
2. Build and publish first release: `make publish VERSION=v0.1.0`
3. Test `install.sh` on the Linux server
4. Update deployment docs to reference the new workflow