### PR TITLE
feat: increase default base image size from 2GB to 5GB

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -80,11 +80,11 @@ sudo ./scripts/build-base-image.sh
 This script automates the full Docker → ext4 pipeline:
 1. Builds the Docker image from `images/Dockerfile`
 2. Exports the container filesystem to a tarball
-3. Creates a 2GB sparse ext4 image at `/var/lib/minions/images/base-ubuntu.ext4`
+3. Creates a 5GB sparse ext4 image at `/var/lib/minions/images/base-ubuntu.ext4`
 4. Mounts the image and extracts the tarball into it
 5. Unmounts and cleans up
 
-The script accepts an optional `--image-size` flag (default: `2G`):
+The script accepts an optional `--image-size` flag (default: `5G`):
 
 ```bash
 sudo ./scripts/build-base-image.sh --image-size 4G
@@ -150,7 +150,7 @@ sudo minions destroy test
 
 /var/lib/minions/
 ├── kernel/vmlinux            # Guest kernel (~46 MB)
-├── images/base-ubuntu.ext4   # Base rootfs (2 GB sparse, ~150 MB actual)
+├── images/base-ubuntu.ext4   # Base rootfs (5 GB sparse, ~600 MB actual)
 ├── vms/                      # Per-VM rootfs copies
 └── minions.db                # SQLite state database
 

--- a/scripts/build-base-image.sh
+++ b/scripts/build-base-image.sh
@@ -7,7 +7,7 @@
 #   sudo ./scripts/build-base-image.sh [--image-size SIZE]
 #
 # Options:
-#   --image-size SIZE    Size for the ext4 image (default: 2G)
+#   --image-size SIZE    Size for the ext4 image (default: 5G)
 #
 # What it does:
 #   1. Builds the Dockerfile at images/Dockerfile → minions-base Docker image
@@ -23,7 +23,7 @@
 set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────────────
-IMAGE_SIZE="${IMAGE_SIZE:-2G}"
+IMAGE_SIZE="${IMAGE_SIZE:-5G}"
 BASE_IMAGE="${BASE_IMAGE:-/var/lib/minions/images/base-ubuntu.ext4}"
 MOUNT_DIR="${MOUNT_DIR:-/tmp/minions-rootfs-mount}"
 DOCKERFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/images"


### PR DESCRIPTION
## Problem

The current 2GB default base image size is too small for modern development workflows. After the OS footprint (~525MB), VMs only have ~1.3GB of free space, which fills up quickly with package installs, git repos, and build artifacts.

## Changes

- **scripts/build-base-image.sh**: Change `IMAGE_SIZE` default from `2G` → `5G`
- **docs/INSTALL.md**: Update documentation to reflect 5GB default

## Impact

- **New VMs** created without `--disk` flag will have **~4.5GB free space** instead of ~1.3GB
- **Sparse file**: Still only uses ~600MB actual disk space (same as before)
- **No breaking changes**: Existing VMs unaffected, can still override with `--disk` flag
- **Better UX**: Users don't run out of disk space as quickly

## Before (2GB default):
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       2.0G  525M  1.3G  29% /
```

## After (5GB default):
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       5.0G  525M  4.5G  11% /
```

## Testing

Rebuild base image on vps-2b1e18f2 to verify:
```bash
sudo ./scripts/build-base-image.sh
sudo ./scripts/bake-agent.sh
minions create test --cpus 1 --memory 512
minions exec test -- df -h /
```