### PR TITLE
Bump NixOS guest image to 25.11 and forward OS in multi-host create

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sudo ./scripts/bake-agent.sh --os ubuntu
 sudo ./scripts/build-base-image.sh --os fedora
 sudo ./scripts/bake-agent.sh --os fedora
 
-# Build NixOS 24.11 (requires Nix installed)
+# Build NixOS 25.11 (requires Nix installed)
 sudo ./scripts/build-base-image.sh --os nixos
 # Note: NixOS doesn't need a separate bake-agent step
 ```
@@ -75,7 +75,7 @@ sudo minions create myvm --cpus 4 --memory 2048
 ```bash
 sudo minions create myvm --os ubuntu   # Ubuntu 24.04 (default)
 sudo minions create myvm --os fedora   # Fedora 41
-sudo minions create myvm --os nixos    # NixOS 24.11
+sudo minions create myvm --os nixos    # NixOS 25.11
 ```
 
 The base image for the chosen OS must be built first (see "Build the base image" above).

--- a/crates/minions-db/src/lib.rs
+++ b/crates/minions-db/src/lib.rs
@@ -165,7 +165,8 @@ fn migrate(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE vms ADD COLUMN proxy_public  INTEGER NOT NULL DEFAULT 0;");
     let _ = conn.execute_batch("ALTER TABLE vms ADD COLUMN owner_id      TEXT;");
     let _ = conn.execute_batch("ALTER TABLE vms ADD COLUMN host_id       TEXT;");
-    let _ = conn.execute_batch("ALTER TABLE vms ADD COLUMN os_type       TEXT NOT NULL DEFAULT 'ubuntu';");
+    let _ = conn
+        .execute_batch("ALTER TABLE vms ADD COLUMN os_type       TEXT NOT NULL DEFAULT 'ubuntu';");
 
     // Index on owner_id — must come after the column exists (idempotent).
     let _ = conn.execute_batch(
@@ -1001,6 +1002,7 @@ mod tests {
             proxy_public: false,
             owner_id: owner_id.map(|s| s.to_string()),
             host_id: Some("local".to_string()),
+            os_type: "ubuntu".to_string(),
         }
     }
 

--- a/crates/minions/src/api.rs
+++ b/crates/minions/src/api.rs
@@ -114,7 +114,7 @@ pub struct CreateRequest {
     /// SSH gateway user who will own this VM.
     /// Supplied by the SSH gateway; absent for direct admin API calls.
     pub owner_id: Option<String>,
-    /// Operating system: "ubuntu" (default) or "fedora".
+    /// Operating system: "ubuntu" (default), "fedora", or "nixos".
     #[serde(default = "default_os")]
     pub os: String,
 }

--- a/crates/minions/src/host_client.rs
+++ b/crates/minions/src/host_client.rs
@@ -25,6 +25,7 @@ impl HostClient {
         memory_mb: u32,
         ssh_pubkey: Option<String>,
         owner_id: Option<String>,
+        os: String,
     ) -> Result<serde_json::Value> {
         #[derive(Serialize)]
         struct CreateRequest {
@@ -33,6 +34,7 @@ impl HostClient {
             memory_mb: u32,
             ssh_pubkey: Option<String>,
             owner_id: Option<String>,
+            os: String,
         }
 
         let req = CreateRequest {
@@ -41,6 +43,7 @@ impl HostClient {
             memory_mb,
             ssh_pubkey,
             owner_id,
+            os,
         };
 
         let resp = self

--- a/crates/minions/src/vm.rs
+++ b/crates/minions/src/vm.rs
@@ -74,10 +74,16 @@ pub async fn create_with_os(
         .await
     } else {
         // Make HTTP call to remote node agent.
-        // TODO: Pass OS parameter to remote host
         let client = host_client::HostClient::new(&host.address, host.api_port);
         let _response = client
-            .create_vm(name, vcpus, memory_mb, ssh_pubkey, owner_id.clone())
+            .create_vm(
+                name,
+                vcpus,
+                memory_mb,
+                ssh_pubkey,
+                owner_id.clone(),
+                os.as_str().to_string(),
+            )
             .await
             .context("remote create_vm call failed")?;
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,7 +51,7 @@ This installs `minions`, `minions-agent`, `minions-node`, and `minions-vsock-cli
 
 ## 4. Download the guest kernel (Ubuntu/Fedora)
 
-Cloud Hypervisor boots an uncompressed `vmlinux` kernel directly — no bootloader or initramfs needed.
+Cloud Hypervisor boots an uncompressed `vmlinux` kernel directly — no bootloader needed. Ubuntu/Fedora VMs boot without initramfs; NixOS VMs use a matching initramfs (`initrd-nixos`).
 
 **For Ubuntu and Fedora VMs**, download the Cloud Hypervisor project kernel:
 
@@ -114,14 +114,15 @@ sudo ./scripts/build-nixos-image.sh
 
 This single script:
 1. Builds the NixOS VM configuration from `images/nixos/flake.nix`
-2. Extracts the matching `vmlinux` kernel from the NixOS build
+2. Extracts the matching `vmlinux` kernel and `initrd` from the NixOS build
 3. Copies the image to `/var/lib/minions/images/base-nixos.ext4`
 4. Copies the kernel to `/var/lib/minions/kernel/vmlinux-nixos`
-5. Injects the `minions-agent` binary into the image
+5. Copies the initramfs to `/var/lib/minions/kernel/initrd-nixos`
+6. Injects the `minions-agent` binary into the image
 
 **No separate bake-agent step is needed** — the agent service is defined in the NixOS configuration and the binary is injected during the build script.
 
-NixOS VMs use their own matched kernel (`vmlinux-nixos`), while Ubuntu/Fedora VMs share the Cloud Hypervisor kernel (`vmlinux`).
+NixOS VMs use their own matched kernel + initramfs (`vmlinux-nixos` + `initrd-nixos`), while Ubuntu/Fedora VMs share the Cloud Hypervisor kernel (`vmlinux`).
 
 ## 6. Bake the agent into the image (Ubuntu/Fedora only)
 
@@ -182,7 +183,8 @@ sudo minions destroy test
 /var/lib/minions/
 ├── kernel/
 │   ├── vmlinux               # Ubuntu/Fedora kernel (~46 MB)
-│   └── vmlinux-nixos         # NixOS kernel (if built)
+│   ├── vmlinux-nixos         # NixOS kernel (if built)
+│   └── initrd-nixos          # NixOS initramfs (if built)
 ├── images/
 │   ├── base-ubuntu.ext4      # Ubuntu rootfs (5 GB sparse, ~600 MB actual)
 │   ├── base-fedora.ext4      # Fedora rootfs (if built)

--- a/images/nixos/configuration.nix
+++ b/images/nixos/configuration.nix
@@ -99,5 +99,5 @@
   };
 
   users.users.root.hashedPassword = "!";
-  system.stateVersion = "24.11";
+  system.stateVersion = "25.11";
 }

--- a/images/nixos/flake.nix
+++ b/images/nixos/flake.nix
@@ -2,7 +2,7 @@
   description = "NixOS VM image for Minions with built-in agent";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
## Summary
- bump NixOS guest image pin from `nixos-24.11` to `nixos-25.11`
- set guest image `system.stateVersion` to `25.11`
- update docs/examples to reference NixOS 25.11
- document NixOS initramfs artifact (`initrd-nixos`) in install docs
- fix multi-host create path to forward selected OS to remote node agents
- fix `minions-db` test fixture to include `os_type`

## Changes
- `images/nixos/flake.nix`: `nixpkgs.url` -> `github:NixOS/nixpkgs/nixos-25.11`
- `images/nixos/configuration.nix`: `system.stateVersion = "25.11"`
- `README.md`: NixOS version labels updated to 25.11
- `docs/INSTALL.md`: NixOS kernel+initramfs docs aligned with current build/runtime
- `crates/minions/src/host_client.rs`: `create_vm()` now sends `os`
- `crates/minions/src/vm.rs`: control-plane remote create forwards `os`
- `crates/minions/src/api.rs`: create request comment updated (ubuntu/fedora/nixos)
- `crates/minions-db/src/lib.rs`: test fixture includes `os_type`

## Validation
- `bun run typecheck && bun run check` *(fails: scripts not defined in this repo)*
- `cargo check`
- `cargo test -p minions-db --quiet`
- `cargo test -p minions --quiet`

Closes #57
