### PR TITLE
Platformize Auth: Per-User API Tokens, Web Registration & Remove SSH Registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +1953,7 @@ dependencies = [
  "axum 0.8.8",
  "chrono",
  "clap",
+ "hex",
  "hickory-resolver",
  "libc",
  "minions-db",
@@ -1959,6 +1966,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "tabled",
  "tokio",
@@ -1988,9 +1996,13 @@ name = "minions-db"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
+ "hex",
+ "rand 0.8.5",
  "rusqlite",
  "serde",
+ "sha2",
  "uuid",
 ]
 

--- a/crates/minions-db/Cargo.toml
+++ b/crates/minions-db/Cargo.toml
@@ -9,3 +9,7 @@ serde = { workspace = true }
 rusqlite = { version = "0.32", features = ["bundled"] }
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
+sha2 = "0.10"
+rand = "0.8"
+base64 = "0.22"
+hex = "0.4"

--- a/crates/minions-db/src/lib.rs
+++ b/crates/minions-db/src/lib.rs
@@ -6,6 +6,38 @@ use rusqlite::{Connection, params};
 use std::path::Path;
 use uuid::Uuid;
 
+/// Compute the fingerprint of an SSH public key.
+/// Accepts keys in the format "ssh-ed25519 AAA... comment" or "ssh-rsa AAA... comment".
+/// Returns the SHA-256 fingerprint in the format "SHA256:xxxx...".
+pub fn fingerprint(public_key: &str) -> Result<String> {
+    use base64::{Engine as _, engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}};
+    use sha2::{Digest, Sha256};
+
+    // Parse the public key string: "type base64-data comment"
+    let parts: Vec<&str> = public_key.trim().split_whitespace().collect();
+    if parts.len() < 2 {
+        anyhow::bail!("invalid SSH public key format: expected 'type base64-data [comment]'");
+    }
+
+    let key_type = parts[0];
+    let key_data = parts[1];
+
+    // Validate key type
+    if !key_type.starts_with("ssh-") && !key_type.starts_with("ecdsa-") {
+        anyhow::bail!("unsupported SSH key type: {}", key_type);
+    }
+
+    // Decode base64 key data
+    let decoded = STANDARD.decode(key_data)
+        .map_err(|e| anyhow::anyhow!("invalid base64 in SSH key: {}", e))?;
+
+    // Compute SHA-256 fingerprint
+    let hash = Sha256::digest(&decoded);
+    let fingerprint = URL_SAFE_NO_PAD.encode(&hash);
+
+    Ok(format!("SHA256:{}", fingerprint))
+}
+
 pub const DB_PATH: &str = "/var/lib/minions/state.db";
 
 /// Represents a VM record in the database.
@@ -54,6 +86,61 @@ pub struct Host {
     pub available_disk_gb: u32,
     pub last_heartbeat: Option<String>,
     pub created_at: String,
+}
+
+/// Represents a user account in the database.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct User {
+    pub id: String,
+    pub email: String,
+    pub name: Option<String>,
+    pub google_id: Option<String>,
+    pub created_at: String,
+}
+
+/// Represents an API token for a user.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ApiToken {
+    pub id: String,
+    pub user_id: String,
+    pub name: String,
+    pub created_at: String,
+    pub last_used: Option<String>,
+    // token_hash is intentionally excluded from serialization
+}
+
+/// Represents an SSH public key for a user.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SshKey {
+    pub id: String,
+    pub user_id: String,
+    pub public_key: String,
+    pub fingerprint: String,
+    pub name: String,
+    pub created_at: String,
+}
+
+/// Generate a new API token.
+/// Returns (raw_token, token_hash) where raw_token is the value to show once,
+/// and token_hash is the SHA-256 hex digest to store in the database.
+pub fn generate_api_token() -> (String, String) {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use rand::RngCore;
+    use sha2::{Digest, Sha256};
+
+    // Generate 32 bytes of randomness
+    let mut random_bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut random_bytes);
+
+    // Encode as base64url (URL-safe, no padding)
+    let encoded = URL_SAFE_NO_PAD.encode(&random_bytes);
+    let raw_token = format!("mnt_{}", encoded);
+
+    // Hash for storage
+    let hash = Sha256::digest(raw_token.as_bytes());
+    let token_hash = hex::encode(hash);
+
+    (raw_token, token_hash)
 }
 
 /// Open (or create) the state database.
@@ -201,6 +288,52 @@ fn migrate(conn: &Connection) -> Result<()> {
         ",
     )
     .context("create hosts table")?;
+
+    // Platform auth: users table (moved from minions-ssh)
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS users (
+            id              TEXT PRIMARY KEY,
+            email           TEXT UNIQUE NOT NULL,
+            created_at      TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS ssh_keys (
+            id              TEXT PRIMARY KEY,
+            user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            public_key      TEXT NOT NULL,
+            fingerprint     TEXT UNIQUE NOT NULL,
+            name            TEXT NOT NULL DEFAULT 'default',
+            created_at      TEXT NOT NULL
+        );
+        ",
+    )
+    .context("create users/ssh_keys tables")?;
+
+    // Idempotent column additions for users table (for google_id, name, password_hash)
+    let _ = conn.execute_batch("ALTER TABLE users ADD COLUMN google_id TEXT;");
+    let _ = conn.execute_batch("ALTER TABLE users ADD COLUMN name TEXT;");
+    let _ = conn.execute_batch("ALTER TABLE users ADD COLUMN password_hash TEXT;");
+
+    // Index for google_id lookups
+    let _ = conn.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_users_google_id ON users(google_id) WHERE google_id IS NOT NULL;",
+    );
+
+    // API tokens table for per-user authentication
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS api_tokens (
+            id              TEXT PRIMARY KEY,
+            user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            token_hash      TEXT UNIQUE NOT NULL,
+            name            TEXT NOT NULL DEFAULT 'default',
+            created_at      TEXT NOT NULL,
+            last_used       TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
+        ",
+    )
+    .context("create api_tokens table")?;
 
     Ok(())
 }
@@ -969,6 +1102,312 @@ fn row_to_host(row: &rusqlite::Row<'_>) -> rusqlite::Result<Host> {
         last_heartbeat: row.get(11)?,
         created_at: row.get(12)?,
     })
+}
+
+// ── User operations ─────────────────────────────────────────────────────────
+
+/// Create a new user from Google OAuth.
+/// Also assigns the free plan subscription automatically.
+pub fn create_user_from_google(
+    conn: &Connection,
+    email: &str,
+    name: Option<&str>,
+    google_id: &str,
+) -> Result<User> {
+    let user_id = Uuid::new_v4().to_string();
+    let sub_id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO users (id, email, name, google_id, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![user_id, email, name, google_id, now],
+    )
+    .context("insert user from google")?;
+
+    // Auto-assign the free plan
+    let _ = conn.execute(
+        "INSERT OR IGNORE INTO subscriptions (id, user_id, plan_id, status, created_at)
+         VALUES (?1, ?2, 'free', 'active', ?3)",
+        params![sub_id, user_id, now],
+    );
+
+    Ok(User {
+        id: user_id,
+        email: email.to_string(),
+        name: name.map(|s| s.to_string()),
+        google_id: Some(google_id.to_string()),
+        created_at: now,
+    })
+}
+
+/// Create a new user from email registration (no Google).
+/// Also assigns the free plan subscription automatically.
+pub fn create_user_from_email(
+    conn: &Connection,
+    email: &str,
+    name: Option<&str>,
+) -> Result<User> {
+    let user_id = Uuid::new_v4().to_string();
+    let sub_id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO users (id, email, name, created_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![user_id, email, name, now],
+    )
+    .context("insert user from email")?;
+
+    // Auto-assign the free plan
+    let _ = conn.execute(
+        "INSERT OR IGNORE INTO subscriptions (id, user_id, plan_id, status, created_at)
+         VALUES (?1, ?2, 'free', 'active', ?3)",
+        params![sub_id, user_id, now],
+    );
+
+    Ok(User {
+        id: user_id,
+        email: email.to_string(),
+        name: name.map(|s| s.to_string()),
+        google_id: None,
+        created_at: now,
+    })
+}
+
+/// Get a user by their ID.
+pub fn get_user(conn: &Connection, id: &str) -> Result<Option<User>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, email, name, google_id, created_at FROM users WHERE id = ?1"
+    )?;
+    let mut rows = stmt.query(params![id])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(User {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            name: row.get(2)?,
+            google_id: row.get(3)?,
+            created_at: row.get(4)?,
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Get a user by their Google ID.
+pub fn get_user_by_google_id(conn: &Connection, google_id: &str) -> Result<Option<User>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, email, name, google_id, created_at FROM users WHERE google_id = ?1"
+    )?;
+    let mut rows = stmt.query(params![google_id])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(User {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            name: row.get(2)?,
+            google_id: row.get(3)?,
+            created_at: row.get(4)?,
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Get a user by their email address.
+pub fn get_user_by_email(conn: &Connection, email: &str) -> Result<Option<User>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, email, name, google_id, created_at FROM users WHERE email = ?1"
+    )?;
+    let mut rows = stmt.query(params![email])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(User {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            name: row.get(2)?,
+            google_id: row.get(3)?,
+            created_at: row.get(4)?,
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Link a Google ID to an existing user (for account linking).
+pub fn set_user_google_id(
+    conn: &Connection,
+    user_id: &str,
+    google_id: &str,
+    name: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE users SET google_id = ?1, name = COALESCE(?2, name) WHERE id = ?3",
+        params![google_id, name, user_id],
+    )
+    .context("set user google_id")?;
+    Ok(())
+}
+
+// ── API Token operations ────────────────────────────────────────────────────
+
+/// Insert a new API token into the database.
+pub fn insert_api_token(
+    conn: &Connection,
+    user_id: &str,
+    token_hash: &str,
+    name: &str,
+) -> Result<ApiToken> {
+    let token_id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO api_tokens (id, user_id, token_hash, name, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![token_id, user_id, token_hash, name, now],
+    )
+    .context("insert api token")?;
+
+    Ok(ApiToken {
+        id: token_id,
+        user_id: user_id.to_string(),
+        name: name.to_string(),
+        created_at: now,
+        last_used: None,
+    })
+}
+
+/// Validate an API token by its hash.
+/// Returns (user_id, email) if valid, None otherwise.
+/// Also updates the last_used timestamp.
+pub fn validate_api_token(
+    conn: &Connection,
+    token_hash: &str,
+) -> Result<Option<(String, String)>> {
+    let now = Utc::now().to_rfc3339();
+
+    // Update last_used and return user info in one query
+    let mut stmt = conn.prepare(
+        "UPDATE api_tokens SET last_used = ?1 WHERE token_hash = ?2
+         RETURNING user_id"
+    )?;
+    let mut rows = stmt.query(params![now, token_hash])?;
+
+    match rows.next()? {
+        Some(row) => {
+            let user_id: String = row.get(0)?;
+            // Get the user's email
+            let mut email_stmt = conn.prepare("SELECT email FROM users WHERE id = ?1")?;
+            let email: String = email_stmt.query_row(params![&user_id], |row| row.get(0))?;
+            Ok(Some((user_id, email)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// List all API tokens for a user (does not include token_hash for security).
+pub fn list_api_tokens(conn: &Connection, user_id: &str) -> Result<Vec<ApiToken>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, user_id, name, created_at, last_used
+         FROM api_tokens WHERE user_id = ?1 ORDER BY created_at"
+    )?;
+    let rows = stmt.query_map(params![user_id], |row| {
+        Ok(ApiToken {
+            id: row.get(0)?,
+            user_id: row.get(1)?,
+            name: row.get(2)?,
+            created_at: row.get(3)?,
+            last_used: row.get(4)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("list api tokens")
+}
+
+/// Revoke (delete) an API token.
+/// Returns true if a token was deleted, false if not found.
+pub fn revoke_api_token(conn: &Connection, user_id: &str, token_id: &str) -> Result<bool> {
+    let rows = conn.execute(
+        "DELETE FROM api_tokens WHERE id = ?1 AND user_id = ?2",
+        params![token_id, user_id],
+    )?;
+    Ok(rows > 0)
+}
+
+// ── SSH Key operations ──────────────────────────────────────────────────────
+
+/// Add an SSH public key for a user.
+pub fn add_ssh_key(
+    conn: &Connection,
+    user_id: &str,
+    public_key: &str,
+    fingerprint: &str,
+    name: &str,
+) -> Result<SshKey> {
+    let key_id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO ssh_keys (id, user_id, public_key, fingerprint, name, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![key_id, user_id, public_key, fingerprint, name, now],
+    )
+    .context("insert ssh key")?;
+
+    Ok(SshKey {
+        id: key_id,
+        user_id: user_id.to_string(),
+        public_key: public_key.to_string(),
+        fingerprint: fingerprint.to_string(),
+        name: name.to_string(),
+        created_at: now,
+    })
+}
+
+/// List all SSH keys for a user.
+pub fn list_ssh_keys(conn: &Connection, user_id: &str) -> Result<Vec<SshKey>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, user_id, public_key, fingerprint, name, created_at
+         FROM ssh_keys WHERE user_id = ?1 ORDER BY created_at"
+    )?;
+    let rows = stmt.query_map(params![user_id], |row| {
+        Ok(SshKey {
+            id: row.get(0)?,
+            user_id: row.get(1)?,
+            public_key: row.get(2)?,
+            fingerprint: row.get(3)?,
+            name: row.get(4)?,
+            created_at: row.get(5)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("list ssh keys")
+}
+
+/// Remove an SSH key by ID.
+/// Returns true if a key was deleted, false if not found.
+pub fn remove_ssh_key(conn: &Connection, user_id: &str, key_id: &str) -> Result<bool> {
+    let rows = conn.execute(
+        "DELETE FROM ssh_keys WHERE id = ?1 AND user_id = ?2",
+        params![key_id, user_id],
+    )?;
+    Ok(rows > 0)
+}
+
+/// Look up a user by SSH key fingerprint.
+pub fn get_user_by_fingerprint(conn: &Connection, fingerprint: &str) -> Result<Option<User>> {
+    let mut stmt = conn.prepare(
+        "SELECT u.id, u.email, u.name, u.google_id, u.created_at
+         FROM users u
+         JOIN ssh_keys k ON k.user_id = u.id
+         WHERE k.fingerprint = ?1"
+    )?;
+    let mut rows = stmt.query(params![fingerprint])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(User {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            name: row.get(2)?,
+            google_id: row.get(3)?,
+            created_at: row.get(4)?,
+        })),
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]

--- a/crates/minions-ssh/src/server.rs
+++ b/crates/minions-ssh/src/server.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use russh::server::{Auth, Handler, Msg, Session};
 use russh::{Channel, ChannelId, CryptoVec, Pty};
-use russh_keys::PublicKeyBase64;
 use russh_keys::key::PublicKey;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, info};
@@ -23,23 +22,12 @@ pub type ServerHandle = russh::server::Handle;
 enum SessionMode {
     /// Not yet determined (between auth and first channel request).
     Pending,
-    /// Collecting the user's email for first-time registration.
-    Registration {
-        after: AfterRegistration,
-        email_buf: String,
-    },
-    /// Registered user in interactive command mode.
+    /// Authenticated user in interactive command mode.
     Command { line_buf: String },
     /// Proxy mode: stdin bytes go to the VM via this writer.
     Proxy {
         vm_stdin: tokio::io::WriteHalf<russh::ChannelStream<russh::client::Msg>>,
     },
-}
-
-#[derive(Clone)]
-enum AfterRegistration {
-    Command,
-    Proxy { vm_name: String },
 }
 
 // ── PTY params (stored during pty_request, forwarded on shell/exec) ───────────
@@ -102,10 +90,6 @@ impl ConnectionHandler {
 
     fn fingerprint(key: &PublicKey) -> String {
         key.fingerprint()
-    }
-
-    fn key_to_str(key: &PublicKey) -> String {
-        format!("{} {}", key.name(), key.public_key_base64())
     }
 
     async fn send(&self, bytes: impl Into<Vec<u8>>) {
@@ -193,86 +177,6 @@ impl ConnectionHandler {
         self.mode = SessionMode::Proxy { vm_stdin };
         Ok(())
     }
-
-    async fn complete_registration(
-        &mut self,
-        email: String,
-        after: AfterRegistration,
-        session: &mut Session,
-        channel: ChannelId,
-    ) -> Result<()> {
-        session.data(channel, CryptoVec::from(b"\r\n".to_vec()));
-
-        if !email.contains('@') || email.len() < 5 {
-            session.data(
-                channel,
-                CryptoVec::from(b"Invalid email. Try again: ".to_vec()),
-            );
-            if let SessionMode::Registration { email_buf, .. } = &mut self.mode {
-                email_buf.clear();
-            }
-            return Ok(());
-        }
-
-        let key = self.pending_key.clone().expect("pending key set");
-        let fp = Self::fingerprint(&key);
-        let key_str = Self::key_to_str(&key);
-
-        let conn = crate::db::open(&self.config.db_path)?;
-        match crate::db::create_user(&conn, &email, &key_str, &fp) {
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("UNIQUE") {
-                    session.data(
-                        channel,
-                        CryptoVec::from(
-                            "Email already registered — use the key that belongs to that account.\r\n"
-                                .as_bytes()
-                                .to_vec(),
-                        ),
-                    );
-                } else {
-                    session.data(
-                        channel,
-                        CryptoVec::from(format!("Registration error: {}\r\n", msg).into_bytes()),
-                    );
-                }
-                return Ok(());
-            }
-            Ok(user) => {
-                self.authed_user = Some(user.clone());
-                info!(email = %user.email, peer = ?self.peer_addr, "new user registered");
-                session.data(
-                    channel,
-                    CryptoVec::from(
-                        format!("✓ Registered! Welcome, {}.\r\n\r\n", user.email).into_bytes(),
-                    ),
-                );
-            }
-        }
-
-        match after {
-            AfterRegistration::Command => {
-                self.mode = SessionMode::Command {
-                    line_buf: String::new(),
-                };
-                session.data(
-                    channel,
-                    CryptoVec::from(b"Type 'help' for available commands.\r\n\r\n$ ".to_vec()),
-                );
-            }
-            AfterRegistration::Proxy { vm_name } => match self.start_proxy_shell(&vm_name).await {
-                Ok(()) => {}
-                Err(e) => {
-                    session.data(
-                        channel,
-                        CryptoVec::from(format!("error: {}\r\n", e).into_bytes()),
-                    );
-                }
-            },
-        }
-        Ok(())
-    }
 }
 
 // ── russh Handler impl ────────────────────────────────────────────────────────
@@ -295,11 +199,13 @@ impl Handler for ConnectionHandler {
 
         if let Some(ref u) = self.authed_user {
             info!(peer = ?self.peer_addr, email = %u.email, "authenticated");
+            Ok(Auth::Accept)
         } else {
-            info!(peer = ?self.peer_addr, ssh_user = %user, "unknown key — will prompt for registration");
+            info!(peer = ?self.peer_addr, ssh_user = %user, "unknown key — rejected");
+            Ok(Auth::Reject {
+                proceed_with_methods: None,
+            })
         }
-
-        Ok(Auth::Accept)
     }
 
     async fn channel_open_session(
@@ -345,25 +251,18 @@ impl Handler for ConnectionHandler {
 
         let is_proxy = self.ssh_username != self.config.command_user;
 
-        // Unregistered user → prompt for email.
+        // This should not happen since unknown keys are rejected at auth time,
+        // but handle it gracefully just in case.
         if self.authed_user.is_none() {
-            let after = if is_proxy {
-                AfterRegistration::Proxy {
-                    vm_name: self.ssh_username.clone(),
-                }
-            } else {
-                AfterRegistration::Command
-            };
-            self.mode = SessionMode::Registration {
-                after,
-                email_buf: String::new(),
-            };
             session.data(
                 channel,
                 CryptoVec::from(
-                    b"Welcome to MINICLANKERS.COM\r\n\r\nEnter your email to register: ".to_vec(),
+                    b"Authentication failed. Register at https://miniclankers.com and add your SSH key.\r\n".to_vec(),
                 ),
             );
+            session.exit_status_request(channel, 1);
+            session.eof(channel);
+            session.close(channel);
             return Ok(());
         }
 
@@ -398,9 +297,9 @@ impl Handler for ConnectionHandler {
         session.channel_success(channel);
         let cmd_str = String::from_utf8_lossy(data).to_string();
 
-        // Unregistered user — must register interactively first.
+        // This should not happen since unknown keys are rejected at auth time.
         if self.authed_user.is_none() {
-            let msg = "Register first: ssh minions@ssh.miniclankers.com\r\n";
+            let msg = "Authentication failed. Register at https://miniclankers.com and add your SSH key.\r\n";
             let _ = session.data(channel, CryptoVec::from(msg.as_bytes().to_vec()));
             session.exit_status_request(channel, 1);
             session.eof(channel);
@@ -437,44 +336,6 @@ impl Handler for ConnectionHandler {
         data: &[u8],
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        // ── Registration: collect email ───────────────────────────────────────
-        // Inner block releases the mutable borrow before calling complete_registration.
-        let reg_action: Option<(String, AfterRegistration)> = {
-            if let SessionMode::Registration { email_buf, after } = &mut self.mode {
-                let mut action = None;
-                for &b in data {
-                    match b {
-                        b'\r' | b'\n' => {
-                            let email = email_buf.trim().to_lowercase();
-                            action = Some((email, after.clone()));
-                            break;
-                        }
-                        0x7f | 0x08 => {
-                            if !email_buf.is_empty() {
-                                email_buf.pop();
-                                session.data(channel, CryptoVec::from(b"\x08 \x08".to_vec()));
-                            }
-                        }
-                        c => {
-                            email_buf.push(c as char);
-                            session.data(channel, CryptoVec::from(vec![c]));
-                        }
-                    }
-                }
-                action
-            } else {
-                None
-            }
-        }; // ← mutable borrow released here
-        if let Some((email, after)) = reg_action {
-            self.complete_registration(email, after, session, channel)
-                .await?;
-            return Ok(());
-        }
-        if matches!(self.mode, SessionMode::Registration { .. }) {
-            return Ok(()); // still collecting input, no newline yet
-        }
-
         // ── Proxy: forward stdin to VM ────────────────────────────────────────
         if let SessionMode::Proxy { vm_stdin } = &mut self.mode {
             if let Err(e) = vm_stdin.write_all(data).await {

--- a/crates/minions/Cargo.toml
+++ b/crates/minions/Cargo.toml
@@ -36,6 +36,8 @@ subtle = { workspace = true }
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
 tabled = "0.17"
+hex = "0.4"
+sha2 = "0.10"
 # HTTP API (daemon)
 axum = "0.8"
 tower-http = { version = "0.6", features = ["trace", "cors"] }

--- a/crates/minions/src/api.rs
+++ b/crates/minions/src/api.rs
@@ -25,7 +25,29 @@ pub fn router(state: AppState) -> Router {
     // Clone auth config for middleware
     let auth_config = state.auth.clone();
 
+    // Public routes (no auth required)
+    let public_router = Router::new()
+        .route("/api/auth/register", post(register));
+
+    // Authenticated routes (require valid token)
+    let auth_router = Router::new()
+        .route("/api/auth/me", get(get_me))
+        .route("/api/auth/tokens", post(create_token))
+        .route("/api/auth/tokens", get(list_tokens))
+        .route("/api/auth/tokens/{id}", delete(revoke_token))
+        .route("/api/auth/ssh-keys", post(add_ssh_key))
+        .route("/api/auth/ssh-keys", get(list_ssh_keys))
+        .route("/api/auth/ssh-keys/{id}", delete(remove_ssh_key))
+        .layer(middleware::from_fn_with_state(
+            auth_config.clone(),
+            auth::require_auth,
+        ));
+
     let mut router = Router::new()
+        // Auth routes
+        .merge(public_router)
+        .merge(auth_router)
+        // VM routes
         .route("/api/vms", post(create_vm))
         .route("/api/vms", get(list_vms))
         .route("/api/vms/{name}", get(get_vm))
@@ -63,7 +85,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/billing/plan", post(billing_set_plan))
         // Per-VM metrics (authenticated)
         .route("/api/vms/{name}/metrics", get(vm_metrics))
-        // Add authentication middleware (checks Bearer token if MINIONS_API_KEY is set)
+        // Add authentication middleware
         .layer(middleware::from_fn_with_state(
             auth_config,
             auth::require_auth,
@@ -208,6 +230,78 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+// ── Auth request/response types ───────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub email: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegisterResponse {
+    pub user_id: String,
+    pub email: String,
+    pub token: String,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MeResponse {
+    pub user_id: String,
+    pub email: String,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateTokenRequest {
+    #[serde(default = "default_token_name")]
+    pub name: String,
+}
+
+fn default_token_name() -> String {
+    "default".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateTokenResponse {
+    pub id: String,
+    pub name: String,
+    pub token: String,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddSshKeyRequest {
+    pub public_key: String,
+    #[serde(default = "default_ssh_key_name")]
+    pub name: String,
+}
+
+fn default_ssh_key_name() -> String {
+    "default".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct SshKeyResponse {
+    pub id: String,
+    pub public_key: String,
+    pub fingerprint: String,
+    pub name: String,
+    pub created_at: String,
+}
+
+impl From<minions_db::SshKey> for SshKeyResponse {
+    fn from(k: minions_db::SshKey) -> Self {
+        SshKeyResponse {
+            id: k.id,
+            public_key: k.public_key,
+            fingerprint: k.fingerprint,
+            name: k.name,
+            created_at: k.created_at,
+        }
+    }
+}
+
 // ── Name validation ───────────────────────────────────────────────────────────
 
 /// Validate that a VM name from a URL path parameter is safe to use in
@@ -266,11 +360,272 @@ fn require_owner_id(owner_id: Option<&str>) -> Result<String, (StatusCode, Json<
     Ok(owner.to_string())
 }
 
-// ── Handlers ──────────────────────────────────────────────────────────────────
+/// Extract owner_id from auth context, enforcing that users can only access their own VMs.
+fn resolve_owner(
+    auth: &auth::AuthContext,
+    provided: Option<&str>,
+) -> Result<Option<String>, (StatusCode, Json<ErrorResponse>)> {
+    Ok(auth::effective_owner(auth, provided))
+}
+
+/// Check if the current user can access a VM.
+fn check_vm_access(
+    auth: &auth::AuthContext,
+    vm: &db::Vm,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if auth::can_access_vm(auth, vm) {
+        Ok(())
+    } else {
+        // Return 404 to not leak existence
+        Err(not_found(&vm.name))
+    }
+}
+
+// ── Auth Handlers ─────────────────────────────────────────────────────────────
+
+/// `POST /api/auth/register` — Register a new user with email.
+async fn register(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    // Validate email
+    let email = req.email.trim().to_lowercase();
+    if email.is_empty() || !email.contains('@') {
+        return Err(bad_request("valid email is required"));
+    }
+
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    // Check if email already exists
+    if let Some(existing) = minions_db::get_user_by_email(&conn, &email).map_err(internal)? {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: format!("email '{}' is already registered", existing.email),
+            }),
+        ));
+    }
+
+    // Create user
+    let user = minions_db::create_user_from_email(&conn, &email, None).map_err(internal)?;
+
+    // Generate API token
+    let (raw_token, token_hash) = minions_db::generate_api_token();
+    minions_db::insert_api_token(&conn, &user.id, &token_hash, "default").map_err(internal)?;
+
+    info!(user_id = %user.id, email = %user.email, "new user registered");
+
+    Ok((StatusCode::CREATED, Json(RegisterResponse {
+        user_id: user.id,
+        email: user.email,
+        token: raw_token,
+        message: "Save this token — it will not be shown again.".to_string(),
+    })))
+}
+
+/// `GET /api/auth/me` — Get current user info.
+async fn get_me(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let user_id = match auth.0 {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin context has no user profile".to_string(),
+                }),
+            ));
+        }
+    };
+
+    let user = minions_db::get_user(&conn, &user_id).map_err(internal)?;
+    match user {
+        Some(u) => Ok(Json(MeResponse {
+            user_id: u.id,
+            email: u.email,
+            name: u.name,
+        })),
+        None => Err(not_found("user")),
+    }
+}
+
+/// `POST /api/auth/tokens` — Create a new API token.
+async fn create_token(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Json(req): Json<CreateTokenRequest>,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let user_id = match auth.0 {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin cannot create tokens".to_string(),
+                }),
+            ));
+        }
+    };
+
+    let (raw_token, token_hash) = minions_db::generate_api_token();
+    let token = minions_db::insert_api_token(&conn, &user_id, &token_hash, &req.name).map_err(internal)?;
+
+    info!(user_id = %user_id, "new api token created");
+
+    Ok((StatusCode::CREATED, Json(CreateTokenResponse {
+        id: token.id,
+        name: token.name,
+        token: raw_token,
+        message: "Save this token — it will not be shown again.".to_string(),
+    })))
+}
+
+/// `GET /api/auth/tokens` — List user's API tokens.
+async fn list_tokens(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let auth = &auth.0;
+    let user_id = match auth {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin has no tokens".to_string(),
+                }),
+            ));
+        }
+    };
+
+    let tokens = minions_db::list_api_tokens(&conn, user_id).map_err(internal)?;
+    Ok(Json(tokens))
+}
+
+/// `DELETE /api/auth/tokens/{id}` — Revoke an API token.
+async fn revoke_token(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(token_id): Path<String>,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let user_id = match auth.0 {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin has no tokens".to_string(),
+                }),
+            ));
+        }
+    };
+
+    let deleted = minions_db::revoke_api_token(&conn, &user_id, &token_id).map_err(internal)?;
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(not_found(&token_id))
+    }
+}
+
+/// `POST /api/auth/ssh-keys` — Add an SSH public key.
+async fn add_ssh_key(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Json(req): Json<AddSshKeyRequest>,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let user_id = match auth.0 {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin has no ssh keys".to_string(),
+                }),
+            ));
+        }
+    };
+
+    // Parse the public key to get fingerprint
+    let fp = minions_db::fingerprint(&req.public_key)
+        .map_err(|e| bad_request(format!("invalid ssh key: {}", e)))?;
+
+    let key = minions_db::add_ssh_key(&conn, &user_id, &req.public_key, &fp, &req.name).map_err(internal)?;
+
+    info!(user_id = %user_id, fingerprint = %fp, "ssh key added");
+
+    Ok((StatusCode::CREATED, Json(SshKeyResponse::from(key))))
+}
+
+/// `GET /api/auth/ssh-keys` — List user's SSH keys.
+async fn list_ssh_keys(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let user_id = match auth.0 {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin has no ssh keys".to_string(),
+                }),
+            ));
+        }
+    };
+
+    let keys = minions_db::list_ssh_keys(&conn, &user_id).map_err(internal)?;
+    Ok(Json(keys.into_iter().map(SshKeyResponse::from).collect::<Vec<_>>()))
+}
+
+/// `DELETE /api/auth/ssh-keys/{id}` — Remove an SSH key.
+async fn remove_ssh_key(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(key_id): Path<String>,
+) -> impl IntoResponse {
+    let conn = db::open(&state.db_path).map_err(internal)?;
+
+    let user_id = match auth.0 {
+        auth::AuthContext::User { user_id, .. } => user_id,
+        auth::AuthContext::Admin => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "admin has no ssh keys".to_string(),
+                }),
+            ));
+        }
+    };
+
+    let deleted = minions_db::remove_ssh_key(&conn, &user_id, &key_id).map_err(internal)?;
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(not_found(&key_id))
+    }
+}
+
+// ── VM Handlers ───────────────────────────────────────────────────────────────
 
 /// `POST /api/vms` — Create a VM.
 async fn create_vm(
     State(state): State<AppState>,
+    auth: auth::Auth,
     Json(req): Json<CreateRequest>,
 ) -> impl IntoResponse {
     info!(name = %req.name, cpus = req.cpus, memory_mb = req.memory_mb, os = %req.os, "create VM");
@@ -281,8 +636,13 @@ async fn create_vm(
         Err(e) => return bad_request(e.to_string()).into_response(),
     };
 
-    let owner_id = match require_owner_id(req.owner_id.as_deref()) {
-        Ok(v) => v,
+    // Resolve owner_id from auth context (user tokens override provided value)
+    let owner_id = match resolve_owner(&auth.0, req.owner_id.as_deref()) {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            // Admin creating a system VM (no owner)
+            return bad_request("owner_id is required for user VMs").into_response();
+        }
         Err(e) => return e.into_response(),
     };
 
@@ -315,9 +675,10 @@ async fn create_vm(
 /// `GET /api/vms` — List VMs.
 ///
 /// Optional query parameter: `?owner_id=<user_id>` — filter by owner.
-/// When absent, all VMs are returned (admin view).
+/// For user tokens, owner is derived from auth context.
 async fn list_vms(
     State(state): State<AppState>,
+    auth: auth::Auth,
     Query(query): Query<ListQuery>,
 ) -> impl IntoResponse {
     let conn = match db::open(&state.db_path) {
@@ -325,18 +686,21 @@ async fn list_vms(
         Err(e) => return internal(e).into_response(),
     };
 
-    let vms_result = if let Some(ref owner_id) = query.owner_id {
-        db::list_vms_by_owner(&conn, owner_id)
+    // Resolve owner_id from auth context
+    let owner_id = match resolve_owner(&auth.0, query.owner_id.as_deref()) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+
+    let vms_result = if let Some(ref oid) = owner_id {
+        db::list_vms_by_owner(&conn, oid)
     } else {
         db::list_vms(&conn)
     };
 
     match vms_result {
         Ok(vms) => {
-            // Correct stale "running" status for dead processes.
-            let mut vms_out: Vec<_> = vms.into_iter().map(VmResponse::from).collect();
-            // (Status reconciliation happens in vm::list; here we return raw DB values.)
-            let _ = vms_out.iter_mut(); // no-op, reconciliation is in vm::list
+            let vms_out: Vec<_> = vms.into_iter().map(VmResponse::from).collect();
             Json(vms_out).into_response()
         }
         Err(e) => internal(e).into_response(),
@@ -344,24 +708,38 @@ async fn list_vms(
 }
 
 /// `GET /api/vms/:name` — Get VM details.
-async fn get_vm(State(state): State<AppState>, Path(name): Path<String>) -> impl IntoResponse {
+async fn get_vm(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
     let conn = match db::open(&state.db_path) {
         Ok(c) => c,
         Err(e) => return internal(e).into_response(),
     };
 
     match db::get_vm(&conn, &name) {
-        Ok(Some(v)) => Json(VmResponse::from(v)).into_response(),
+        Ok(Some(v)) => {
+            // Check ownership for user tokens
+            if let Err(e) = check_vm_access(&auth.0, &v) {
+                return e.into_response();
+            }
+            Json(VmResponse::from(v)).into_response()
+        }
         Ok(None) => not_found(&name).into_response(),
         Err(e) => internal(e).into_response(),
     }
 }
 
 /// `DELETE /api/vms/:name` — Destroy a VM.
-async fn destroy_vm(State(state): State<AppState>, Path(name): Path<String>) -> impl IntoResponse {
+async fn destroy_vm(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
     info!(name = %name, "destroy VM");
 
-    // Check VM exists (sync, connection dropped before await).
+    // Check VM exists and ownership (sync, connection dropped before await).
     {
         let conn = match db::open(&state.db_path) {
             Ok(c) => c,
@@ -370,7 +748,11 @@ async fn destroy_vm(State(state): State<AppState>, Path(name): Path<String>) -> 
         match db::get_vm(&conn, &name) {
             Ok(None) => return not_found(&name).into_response(),
             Err(e) => return internal(e).into_response(),
-            Ok(Some(_)) => {}
+            Ok(Some(v)) => {
+                if let Err(e) = check_vm_access(&auth.0, &v) {
+                    return e.into_response();
+                }
+            }
         }
     } // conn dropped here
 
@@ -383,15 +765,38 @@ async fn destroy_vm(State(state): State<AppState>, Path(name): Path<String>) -> 
     }
 }
 
+/// Helper to get VM with ownership check.
+fn get_vm_checked(
+    db_path: &str,
+    auth: &auth::AuthContext,
+    name: &str,
+) -> Result<db::Vm, (StatusCode, Json<ErrorResponse>)> {
+    let conn = db::open(db_path).map_err(internal)?;
+    let vm = db::get_vm(&conn, name).map_err(internal)?;
+    match vm {
+        Some(v) => {
+            check_vm_access(auth, &v)?;
+            Ok(v)
+        }
+        None => Err(not_found(name)),
+    }
+}
+
 /// `POST /api/vms/:name/stop` — Halt a VM (CH process + TAP), keep rootfs + DB record.
-async fn stop_vm(State(state): State<AppState>, Path(name): Path<String>) -> impl IntoResponse {
+async fn stop_vm(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
     info!(name = %name, "stop VM");
+    if let Err(e) = get_vm_checked(&state.db_path, &auth.0, &name) {
+        return e.into_response();
+    }
     let db_path = state.db_path.as_str().to_string();
     match vm::stop(&db_path, &name).await {
         Ok(v) => Json(VmResponse::from(v)).into_response(),
         Err(e) => {
             let msg = e.to_string();
-            // Only 404 when the VM genuinely doesn't exist in the DB.
             if msg.contains("VM '") && msg.contains("' not found") {
                 not_found(&name).into_response()
             } else if msg.contains("already stopped") {
@@ -404,8 +809,15 @@ async fn stop_vm(State(state): State<AppState>, Path(name): Path<String>) -> imp
 }
 
 /// `POST /api/vms/:name/start` — Start a stopped VM using its existing rootfs.
-async fn start_vm(State(state): State<AppState>, Path(name): Path<String>) -> impl IntoResponse {
+async fn start_vm(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
     info!(name = %name, "start VM");
+    if let Err(e) = get_vm_checked(&state.db_path, &auth.0, &name) {
+        return e.into_response();
+    }
     let db_path = state.db_path.as_str().to_string();
     match vm::start(&db_path, &name).await {
         Ok(v) => Json(VmResponse::from(v)).into_response(),
@@ -423,14 +835,20 @@ async fn start_vm(State(state): State<AppState>, Path(name): Path<String>) -> im
 }
 
 /// `POST /api/vms/:name/restart` — Reboot a running VM via ACPI signal.
-async fn restart_vm(State(state): State<AppState>, Path(name): Path<String>) -> impl IntoResponse {
+async fn restart_vm(
+    State(state): State<AppState>,
+    auth: auth::Auth,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
     info!(name = %name, "restart VM");
+    if let Err(e) = get_vm_checked(&state.db_path, &auth.0, &name) {
+        return e.into_response();
+    }
     let db_path = state.db_path.as_str().to_string();
     match vm::restart(&db_path, &name).await {
         Ok(v) => Json(VmResponse::from(v)).into_response(),
         Err(e) => {
             let msg = e.to_string();
-            // Only 404 when the VM genuinely doesn't exist in the DB.
             if msg.contains("VM '") && msg.contains("' not found") {
                 not_found(&name).into_response()
             } else if msg.contains("not running") {

--- a/crates/minions/src/auth.rs
+++ b/crates/minions/src/auth.rs
@@ -11,17 +11,28 @@ use serde::Serialize;
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
 
+#[derive(Clone, Debug)]
+pub enum AuthContext {
+    /// Admin API key — full access, can specify owner_id.
+    Admin,
+    /// Per-user API token — scoped to user's resources.
+    User { user_id: String, email: String },
+}
+
 #[derive(Clone)]
 pub struct AuthConfig {
-    /// API key for bearer token authentication.
+    /// API key for admin bearer token authentication.
     /// If None, authentication is disabled (INSECURE - development only).
     pub api_key: Option<Arc<String>>,
+    /// Path to the SQLite database for user token lookups.
+    pub db_path: String,
 }
 
 impl AuthConfig {
-    pub fn new(api_key: Option<String>) -> Self {
+    pub fn new(api_key: Option<String>, db_path: String) -> Self {
         Self {
             api_key: api_key.map(Arc::new),
+            db_path,
         }
     }
 
@@ -31,8 +42,8 @@ impl AuthConfig {
 }
 
 #[derive(Serialize)]
-struct ErrorResponse {
-    error: String,
+pub struct ErrorResponse {
+    pub error: String,
 }
 
 /// Compare two strings in constant time to prevent timing side-channel attacks.
@@ -40,14 +51,22 @@ pub fn constant_time_eq(a: &str, b: &str) -> bool {
     a.as_bytes().ct_eq(b.as_bytes()).into()
 }
 
+/// Hash a raw token using SHA-256 for database lookup.
+fn hash_token(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(token.as_bytes()))
+}
+
 /// Middleware that checks for a valid bearer token.
+/// Supports both admin API key and per-user API tokens (mnt_... format).
 pub async fn require_auth(
     State(auth): State<AuthConfig>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Response {
-    // If auth is disabled, pass through
+    // If auth is disabled (no api_key configured), treat as admin
     if !auth.enabled() {
+        request.extensions_mut().insert(AuthContext::Admin);
         return next.run(request).await;
     }
 
@@ -62,33 +81,134 @@ pub async fn require_auth(
     match auth_header {
         Some(header) if header.starts_with("Bearer ") => {
             let token = &header[7..]; // Skip "Bearer "
-            // Use constant-time comparison to prevent timing attacks
+
+            // Check if it's the admin key
             if constant_time_eq(token, expected_key.as_str()) {
-                // Valid token - proceed
-                next.run(request).await
-            } else {
-                // Invalid token
-                (
-                    StatusCode::UNAUTHORIZED,
-                    Json(ErrorResponse {
-                        error: "invalid API key".to_string(),
-                    }),
-                )
-                    .into_response()
+                request.extensions_mut().insert(AuthContext::Admin);
+                return next.run(request).await;
             }
+
+            // Check if it's a user token (mnt_... format)
+            if token.starts_with("mnt_") {
+                let token_hash = hash_token(token);
+                match minions_db::open(&auth.db_path) {
+                    Ok(conn) => {
+                        match minions_db::validate_api_token(&conn, &token_hash) {
+                            Ok(Some((user_id, email))) => {
+                                request.extensions_mut().insert(AuthContext::User {
+                                    user_id,
+                                    email,
+                                });
+                                return next.run(request).await;
+                            }
+                            Ok(None) => {
+                                // Token not found or revoked
+                            }
+                            Err(e) => {
+                                tracing::error!("token validation error: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("failed to open db for auth: {}", e);
+                    }
+                }
+            }
+
+            // Invalid token
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse {
+                    error: "invalid API key or token".to_string(),
+                }),
+            )
+                .into_response()
         }
         _ => {
             // Missing or malformed Authorization header
             (
                 StatusCode::UNAUTHORIZED,
                 Json(ErrorResponse {
-                    error: "missing or invalid Authorization header (expected: Bearer <api_key>)"
+                    error: "missing or invalid Authorization header (expected: Bearer <token>)"
                         .to_string(),
                 }),
             )
                 .into_response()
         }
     }
+}
+
+/// Extractor for AuthContext from request extensions.
+#[derive(Clone)]
+pub struct Auth(pub AuthContext);
+
+impl std::ops::Deref for Auth {
+    type Target = AuthContext;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Auth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<S> axum::extract::FromRequestParts<S> for Auth
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, Json<ErrorResponse>);
+
+    async fn from_request_parts(parts: &mut axum::http::request::Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<AuthContext>()
+            .cloned()
+            .map(Auth)
+            .ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(ErrorResponse {
+                        error: "authentication required".to_string(),
+                    }),
+                )
+            })
+    }
+}
+
+/// Extract the AuthContext from a request (for use in middleware).
+/// Panics if the auth middleware hasn't run.
+pub fn auth_context(request: &Request) -> &AuthContext {
+    request
+        .extensions()
+        .get::<AuthContext>()
+        .expect("auth middleware must run before extracting auth context")
+}
+
+/// Get the effective owner_id from auth context.
+/// - Admin: uses the provided owner_id (from query/body) if given
+/// - User: always returns the user's own id (ignores provided value)
+pub fn effective_owner(auth: &AuthContext, provided: Option<&str>) -> Option<String> {
+    match auth {
+        AuthContext::Admin => provided.map(|s| s.to_string()),
+        AuthContext::User { user_id, .. } => Some(user_id.clone()),
+    }
+}
+
+/// Check if the auth context can access a VM.
+pub fn can_access_vm(auth: &AuthContext, vm: &minions_db::Vm) -> bool {
+    match auth {
+        AuthContext::Admin => true,
+        AuthContext::User { user_id, .. } => vm.owner_id.as_deref() == Some(user_id.as_str()),
+    }
+}
+
+/// Middleware that allows public access (no auth required).
+/// Used for registration and OAuth endpoints.
+pub async fn public_access(request: Request, next: Next) -> Response {
+    next.run(request).await
 }
 
 #[cfg(test)]
@@ -114,5 +234,62 @@ mod tests {
     fn test_constant_time_eq_empty() {
         assert!(constant_time_eq("", ""));
         assert!(!constant_time_eq("", "nonempty"));
+    }
+
+    #[test]
+    fn test_effective_owner() {
+        let admin = AuthContext::Admin;
+        assert_eq!(effective_owner(&admin, None), None);
+        assert_eq!(effective_owner(&admin, Some("user-123")), Some("user-123".to_string()));
+
+        let user = AuthContext::User {
+            user_id: "user-456".to_string(),
+            email: "test@example.com".to_string(),
+        };
+        assert_eq!(effective_owner(&user, None), Some("user-456".to_string()));
+        assert_eq!(effective_owner(&user, Some("user-123")), Some("user-456".to_string()));
+    }
+
+    #[test]
+    fn test_can_access_vm() {
+        let admin = AuthContext::Admin;
+        let vm = minions_db::Vm {
+            name: "test".to_string(),
+            status: "running".to_string(),
+            ip: "10.0.0.1".to_string(),
+            vsock_cid: 3,
+            ch_pid: None,
+            ch_api_socket: "/tmp/test.sock".to_string(),
+            ch_vsock_socket: "/tmp/vsock.sock".to_string(),
+            tap_device: "tap0".to_string(),
+            mac_address: "02:00:00:00:00:01".to_string(),
+            vcpus: 2,
+            memory_mb: 1024,
+            rootfs_path: "/tmp/rootfs.ext4".to_string(),
+            created_at: "2025-01-01".to_string(),
+            stopped_at: None,
+            proxy_port: 80,
+            proxy_public: false,
+            owner_id: Some("user-123".to_string()),
+            host_id: None,
+            os_type: "ubuntu".to_string(),
+        };
+        assert!(can_access_vm(&admin, &vm));
+
+        let owner = AuthContext::User {
+            user_id: "user-123".to_string(),
+            email: "owner@example.com".to_string(),
+        };
+        assert!(can_access_vm(&owner, &vm));
+
+        let other = AuthContext::User {
+            user_id: "user-456".to_string(),
+            email: "other@example.com".to_string(),
+        };
+        assert!(!can_access_vm(&other, &vm));
+
+        let mut vm_no_owner = vm.clone();
+        vm_no_owner.owner_id = None;
+        assert!(!can_access_vm(&other, &vm_no_owner));
     }
 }

--- a/crates/minions/src/server.rs
+++ b/crates/minions/src/server.rs
@@ -121,7 +121,7 @@ pub async fn serve(
         info!("✓ API authentication enabled");
     }
 
-    let auth = auth::AuthConfig::new(api_key.clone());
+    let auth = auth::AuthConfig::new(api_key.clone(), db_path.clone());
 
     // ── CORS origins ──────────────────────────────────────────────────────────
     let cors_origins: Vec<String> = std::env::var("MINIONS_CORS_ORIGINS")


### PR DESCRIPTION
## Summary

This PR implements per-user authentication for minions, transforming it from a single-admin platform to a multi-tenant cloud offering.

## Changes

### Database (minions-db)
- Added `api_tokens` table for per-user API token storage (SHA-256 hashed)
- Extended `users` table with `google_id`, `name`, `password_hash` columns
- Added token generation (`mnt_<base64>` format) and validation functions
- Added user management functions: `create_user_from_google`, `create_user_from_email`, etc.
- Added SSH key management functions moved from minions-ssh
- Added SSH key fingerprint calculation

### Auth Middleware (minions/src/auth.rs)
- Refactored to support tri-state auth: `AuthContext::Admin` vs `AuthContext::User`
- Admin API key continues to work (full access)
- User tokens (`mnt_...` format) are validated against `api_tokens` table
- Added `Auth` extractor for easy access in handlers
- Added helper functions: `effective_owner`, `can_access_vm`

### API Endpoints (minions/src/api.rs)
- **New public endpoint**: `POST /api/auth/register` - Email registration
- **New authenticated endpoints**:
  - `GET /api/auth/me` - Current user info
  - `POST /api/auth/tokens` - Create API token
  - `GET /api/auth/tokens` - List tokens
  - `DELETE /api/auth/tokens/{id}` - Revoke token
  - `POST /api/auth/ssh-keys` - Add SSH key
  - `GET /api/auth/ssh-keys` - List SSH keys  
  - `DELETE /api/auth/ssh-keys/{id}` - Remove SSH key
- Updated all VM handlers to enforce ownership based on auth context
- Users can only access their own VMs (returns 404 for others to avoid leaking existence)
- Admin can still access all VMs

### SSH Gateway (minions-ssh)
- **Removed SSH registration flow** - unknown keys are now rejected
- Gateway is now a pure access layer: authenticate known users, reject unknowns
- Error message points users to web registration

## Auth Flow

```
Web Registration (POST /api/auth/register)
    ↓
Receive API token (mnt_...)
    ↓
Use token for API access OR Dashboard login
    ↓
Add SSH keys via API/Dashboard
    ↓
SSH into gateway (key must be registered)
```

## Testing

```bash
# Register a new user
curl -X POST http://localhost:3000/api/auth/register \
  -H "Content-Type: application/json" \
  -d {'email': 'user@example.com'}"